### PR TITLE
Update mapGenerator.js

### DIFF
--- a/static/mapGenerator.js
+++ b/static/mapGenerator.js
@@ -480,7 +480,7 @@ function printEspece(tabEspece, tabCdRef) {
   i = 0;
   while (i < tabEspece.length) {
     stringEspece +=
-      "<li> <a href='./espece/" + tabCdRef[i] + "'>" + tabEspece[i] + "</li>";
+      "<li> <a href='../espece/" + tabCdRef[i] + "'>" + tabEspece[i] + "</li>";
     i = i + 1;
   }
   return stringEspece;

--- a/static/mapGenerator.js
+++ b/static/mapGenerator.js
@@ -480,7 +480,9 @@ function printEspece(tabEspece, tabCdRef) {
   i = 0;
   while (i < tabEspece.length) {
     stringEspece +=
-      "<li> <a href='../espece/" + tabCdRef[i] + "'>" + tabEspece[i] + "</li>";
+      "<li> <a href='" +
+      configuration.URL_APPLICATION +
+      "/espece/" + tabCdRef[i] + "'>" + tabEspece[i] + "</li>";
     i = i + 1;
   }
   return stringEspece;


### PR DESCRIPTION
Corrige les liens erronés vers des fiches espèces lorsque : depuis une fiche commune **avec affichage par maille**, clic sur une maille de la carte puis, sur le lien d'une espèce listée dans l'infobulle (monatlas.fr/**commune**/espece/CD_NOM au lieu de monatlas.fr/espece/CD_NOM)