### PR TITLE
restrict map bound and zoom

### DIFF
--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -35,6 +35,8 @@ class SecretSchemaConf(Schema):
 
 class MapConfig(Schema):
     LAT_LONG = fields.List(fields.Float(), missing=[44.7952, 6.2287])
+    MIN_ZOOM = fields.Integer(missing=6)
+    MAX_BOUNDS= fields.List(fields.List(fields.Float()),missing=[[41.463,-1.876],[51.62,8.6]])
     FIRST_MAP = fields.Dict(missing=MAP_1)
     SECOND_MAP = fields.Dict(missing=MAP_2)
     ZOOM = fields.Integer(missing=10)

--- a/static/mapGenerator.js
+++ b/static/mapGenerator.js
@@ -13,6 +13,8 @@ function generateMap() {
   var map = L.map("map", {
     crs: L.CRS.EPSG3857,
     center: configuration.MAP.LAT_LONG,
+    maxBounds:configuration.MAP.MAX_BOUNDS,
+    minZoom:configuration.MAP.MIN_ZOOM,
     geosearch: true,
     zoom: configuration.MAP.ZOOM,
     layers: [firstMapTile],


### PR DESCRIPTION
Ajout de 2 paramètres permettant de restreindre l'affichage de la carte sur un territoire
(par défaut : zoom 6 et France métrop)