### PR TITLE
Ne pas utiliser sudo pour lancer "install_db.sh"

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -170,7 +170,7 @@ Lancez le fichier fichier d'installation de la base de données :
 ::
 
     cd /home/`whoami`/atlas
-    sudo ./install_db.sh
+    ./install_db.sh
 
 
 :notes:


### PR DESCRIPTION
Sauf erreur de ma part, il ne semble plus utile de lancer le script "$HOME/atlas/install_db.sh" avec "sudo". Le faire renvoie le message "This script should NOT be run as root". Sans sudo le script s'exécute correctement.