### PR TITLE
Fix index.css: resize spinner icon size

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -127,7 +127,7 @@ h3.title-spaced {
   margin: 0px;
 }
 
-#searchTaxonsStat {
+#searchTaxonsStat, #searchCommunesStat {
   background-position: right center;
   background-repeat: no-repeat;
   background-size: 25px 25px;


### PR DESCRIPTION
Add same CSS rules to 'commune' search input that species input.

Fix #227, fix cbn-alpin/silene-geonature#23.