### PR TITLE
Choix de l'affichage ou non des stats ses fiches espèces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ data/ref/communes.dbf
 data/ref/communes.prj
 
 static/custom/territoire.json
+static/custom/territoire_limit2.json
 static/custom/glossaire.json
 static/custom/custom.css
 static/custom/maps-custom.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ atlas/configuration/config.py
 atlas/configuration/settings.ini
 robots.txt
 .htaccess
+.htpassword
 venv/*
 venv3/*
 

--- a/.htpasswd
+++ b/.htpasswd
@@ -1,1 +1,0 @@
-Sturnus:$apr1$oL59qW1C$fUCbZfFeG4TyHRYbFZM1b0

--- a/.htpasswd
+++ b/.htpasswd
@@ -1,0 +1,1 @@
+Sturnus:$apr1$oL59qW1C$fUCbZfFeG4TyHRYbFZM1b0

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -49,8 +49,8 @@ class MapConfig(Schema):
 
 
 class StatConfig(Schema):
-    ENABLE_CLASSE_ALTITUDE = fields.Boolean(missing=True)
-    ENABLE_OBS_MENSUELLE = fields.Boolean(missing=True)
+    DISPLAY_CLASSE_ALTITUDE = fields.Boolean(missing=True)
+    DISPLAY_OBS_MENSUELLE = fields.Boolean(missing=True)
 
 
 class AtlasConfig(Schema):

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -48,6 +48,11 @@ class MapConfig(Schema):
     ENABLE_SLIDER = fields.Boolean(missing=True)
 
 
+class StatConfig(Schema):
+    ENABLE_CLASSE_ALTITUDE = fields.Boolean(missing=True)
+    ENABLE_OBS_MENSUELLE = fields.Boolean(missing=True)
+
+
 class AtlasConfig(Schema):
     modeDebug = fields.Boolean(missing=False)
     STRUCTURE = fields.String(missing="Nom de la structure")
@@ -129,6 +134,8 @@ class AtlasConfig(Schema):
     )
 
     MAP = fields.Nested(MapConfig, missing=dict())
+    STAT = fields.Nested(StatConfig, missing=dict())
+    
     # Specify how communes are ordered
     #   if true by length else by name
     ORDER_COMMUNES_BYLENGTH = fields.Boolean(missing=False)

--- a/static/chart.js
+++ b/static/chart.js
@@ -1,58 +1,58 @@
-
 // alti graph
-Morris.Bar({
-            element:"altiChart",
-            data : dataset,
-            xkey: "altitude",
-            ykeys : ["value"],
-            labels: ['Observation(s)'],
-            xLabelAngle: 45,
-            hideHover: 'auto',
-            resize: true,
-            axes: true,
-            gridIntegers: true
-            /*yLabelFormat: function(y){return y != Math.round(y)?'':y;}*/
-/*            horizontal: true
-*/        });
+if (configuration.STAT.ENABLE_CLASSE_ALTITUDE) {
+    Morris.Bar({
+                element:"altiChart",
+                data : dataset,
+                xkey: "altitude",
+                ykeys : ["value"],
+                labels: ['Observation(s)'],
+                xLabelAngle: 45,
+                hideHover: 'auto',
+                resize: true,
+                axes: true,
+                gridIntegers: true
+                /*yLabelFormat: function(y){return y != Math.round(y)?'':y;}*/
+    /*            horizontal: true
+    */        });
 
+    svgbis=d3.selectAll("svg");
 
+            svgbis.append("g")
+            .append("text")
+                .attr("y", "90%")
+                .attr("x", "100%")
+                .attr("dy", ".71em")
+                .attr("fill", "#888888")
+                .attr("font-size", "10px")
+                .style("text-anchor", "end")
+                .text("Altitude(m)");
+}
 
-svgbis=d3.selectAll("svg");
-
-        svgbis.append("g")
-        .append("text")
-            .attr("y", "90%")
-            .attr("x", "100%")
-            .attr("dy", ".71em")
-            .attr("fill", "#888888")
-            .attr("font-size", "10px")
-            .style("text-anchor", "end")
-            .text("Altitude(m)");
-
-
-var phenologyChart =  Morris.Bar({
-                        element:"phenologyChart",
-                        data : months,
-                        xkey: "mois",
-                        ykeys : ["value"],
-                        labels: ['Observation(s)'],
-                        xLabelAngle: 60,
-                        hideHover: 'auto',
-                        resize: true,
-                        axes: true,
-                    });
-svgContainer = d3.selectAll("svg");
-    svgContainer.append("g")
-        .append("text")
-            .attr("transform", "rotate(-90)")
-            .attr("y", '0%')
-            .attr('x', '-15%')
-            .attr("dy", ".71em")
-            .attr("fill", "#888888")
-            .attr("font-size", "10px")
-            .style("text-anchor", "end")
-            .text("Observations");
-
+// month graph
+if (configuration.STAT.ENABLE_OBS_MENSUELLE) {
+    var phenologyChart =  Morris.Bar({
+                            element:"phenologyChart",
+                            data : months,
+                            xkey: "mois",
+                            ykeys : ["value"],
+                            labels: ['Observation(s)'],
+                            xLabelAngle: 60,
+                            hideHover: 'auto',
+                            resize: true,
+                            axes: true,
+                        });
+    svgContainer = d3.selectAll("svg");
+        svgContainer.append("g")
+            .append("text")
+                .attr("transform", "rotate(-90)")
+                .attr("y", '0%')
+                .attr('x', '-15%')
+                .attr("dy", ".71em")
+                .attr("fill", "#888888")
+                .attr("font-size", "10px")
+                .style("text-anchor", "end")
+                .text("Observations");
+}
 
 
 rect = d3.selectAll("rect");

--- a/static/chart.js
+++ b/static/chart.js
@@ -1,5 +1,5 @@
 // alti graph
-if (configuration.STAT.ENABLE_CLASSE_ALTITUDE) {
+if (configuration.STAT.DISPLAY_CLASSE_ALTITUDE) {
     Morris.Bar({
                 element:"altiChart",
                 data : dataset,
@@ -29,7 +29,7 @@ if (configuration.STAT.ENABLE_CLASSE_ALTITUDE) {
 }
 
 // month graph
-if (configuration.STAT.ENABLE_OBS_MENSUELLE) {
+if (configuration.STAT.DISPLAY_OBS_MENSUELLE) {
     var phenologyChart =  Morris.Bar({
                             element:"phenologyChart",
                             data : months,

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -581,13 +581,18 @@
 
             </div>
             {% endif %}
-
+            {% if configuration.STAT.ENABLE_CLASSE_ALTITUDE or configuration.STAT.ENABLE_OBS_MENSUELLE %}
             <div class="panel panel-default" id="graphBloc">
-                <h4 class="title-bar title-spaced center strong">Observations par classes d'altitudes</h4>
-                <div id="altiChart"></div>
-                <h4 class="title-bar title-spaced center strong">Observations mensuelles</h4>
-                <div id="phenologyChart"></div>
+                {% if configuration.STAT.ENABLE_CLASSE_ALTITUDE %}
+                    <h4 class="title-bar title-spaced center strong">Observations par classes d'altitudes</h4>
+                    <div id="altiChart"></div>
+                {% endif %}
+                {% if configuration.STAT.ENABLE_OBS_MENSUELLE %}
+                    <h4 class="title-bar title-spaced center strong">Observations mensuelles</h4>
+                    <div id="phenologyChart"></div>
+                {% endif %}
             </div>
+            {% endif %}
         </div>
     </div>
         {% if configuration.AFFICHAGE_FOOTER %}
@@ -608,6 +613,8 @@
             var taxonYearMin = {{taxon.taxonSearch.yearmin}};
             var cd_ref = {{taxon.taxonSearch.cd_ref}};
             var nb_obs = {{taxon.taxonSearch.nb_obs}};
+            if (configuration.STAT.ENABLE_CLASSE_ALTITUDE) {var dataset = {{altitudes|tojson}};}
+            if (configuration.STAT.ENABLE_OBS_MENSUELLE) {var months = {{months|tojson}};}  
     </script>
 
     <script src="{{url_for('static', filename='custom/maps-custom.js') }}"></script>

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -581,13 +581,13 @@
 
             </div>
             {% endif %}
-            {% if configuration.STAT.ENABLE_CLASSE_ALTITUDE or configuration.STAT.ENABLE_OBS_MENSUELLE %}
+            {% if configuration.STAT.DISPLAY_CLASSE_ALTITUDE or configuration.STAT.DISPLAY_OBS_MENSUELLE %}
             <div class="panel panel-default" id="graphBloc">
-                {% if configuration.STAT.ENABLE_CLASSE_ALTITUDE %}
+                {% if configuration.STAT.DISPLAY_CLASSE_ALTITUDE %}
                     <h4 class="title-bar title-spaced center strong">Observations par classes d'altitudes</h4>
                     <div id="altiChart"></div>
                 {% endif %}
-                {% if configuration.STAT.ENABLE_OBS_MENSUELLE %}
+                {% if configuration.STAT.DISPLAY_OBS_MENSUELLE %}
                     <h4 class="title-bar title-spaced center strong">Observations mensuelles</h4>
                     <div id="phenologyChart"></div>
                 {% endif %}
@@ -613,8 +613,8 @@
             var taxonYearMin = {{taxon.taxonSearch.yearmin}};
             var cd_ref = {{taxon.taxonSearch.cd_ref}};
             var nb_obs = {{taxon.taxonSearch.nb_obs}};
-            if (configuration.STAT.ENABLE_CLASSE_ALTITUDE) {var dataset = {{altitudes|tojson}};}
-            if (configuration.STAT.ENABLE_OBS_MENSUELLE) {var months = {{months|tojson}};}  
+            if (configuration.STAT.DISPLAY_CLASSE_ALTITUDE) {var dataset = {{altitudes|tojson}};}
+            if (configuration.STAT.DISPLAY_OBS_MENSUELLE) {var months = {{months|tojson}};}  
     </script>
 
     <script src="{{url_for('static', filename='custom/maps-custom.js') }}"></script>


### PR DESCRIPTION
Pour avoir le choix d'afficher ou non les graphiques sur les fiches espèces :

- **Financement : CEN Pays de la Loire**
- Affichage de la répartition mensuelle oui/non avec le paramètre DISPLAY_OBS_MENSUELLE
- Affichage de la répartition en altitude oui/non avec le paramètre DISPLAY_CLASSE_ALTITUDE

     