### PR TITLE
Affichage des infos "stat" des fiches espèces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ atlas/configuration/config.py
 atlas/configuration/settings.ini
 robots.txt
 .htaccess
+.htpasswd
 venv/*
 venv3/*
 

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -115,7 +115,8 @@ class AtlasConfig(Schema):
             }
         }
     )
-    INFOS_POPUP = fields.Boolean(missing=True)
+    INFOS_POPUP = fields.Boolean(missing=False)
+    DISPLAY_OBSERVERS = fields.Boolean(missing=True)
 
     AFFICHAGE_MAILLE = fields.Boolean(missing=False)
     ZOOM_LEVEL_POINT = fields.Integer(missing=11)

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -115,6 +115,7 @@ class AtlasConfig(Schema):
             }
         }
     )
+    INFOS_POPUP = fields.Boolean(missing=True)
 
     AFFICHAGE_MAILLE = fields.Boolean(missing=False)
     ZOOM_LEVEL_POINT = fields.Integer(missing=11)

--- a/static/css/atlas.css
+++ b/static/css/atlas.css
@@ -101,6 +101,18 @@ a {
   border-color: var(--main-color);
 }
 
+.btn.btn-light {
+  color: var(--main-color) !important;
+  border-color: var(--main-color) !important;
+  background-color: white; 
+}
+
+.btn.btn-light:hover {
+  background-color: var(--main-color);
+  color:  white !important;
+  border-color: var(--main-color);
+}
+
 .rowMargin {
   margin-left: 0px;
   margin-right: 0px;

--- a/static/css/ficheEspece.css
+++ b/static/css/ficheEspece.css
@@ -179,6 +179,7 @@ hr.small-hr {
 
 div#otherInformations {
   padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .hiddenRow {

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -302,7 +302,16 @@
                     <!-- Si on veux les infos sous la cartes en pop-up -->
                     {% if configuration.INFOS_POPUP %}
 
-                            <div class="col-lg-6 col-sm-12">
+                        <!-- au minimum il y a 1 btn : communes -->
+                        {% set nb_btn = 1 %}
+                        <!-- si on affiche les observateurs : + 1 btn -->
+                        {% if configuration.DISPLAY_OBSERVERS %}{% set nb_btn = nb_btn + 1 %}{% endif %}
+                        
+
+                        {% if nb_btn == 1 %} <div class="col-lg-offset-3 col-lg-6 col-sm-12">
+                        {% elif nb_btn == 2 %} <div class="col-lg-6 col-sm-12">
+                        {% else %} <div class="col-xs-12">
+                        {% endif %}
 
                                 <button type="button" class="btn btn-light btn-block btn-lg" data-toggle="modal"
                                         data-target="#listCommunes">
@@ -343,45 +352,57 @@
 
                             </div>
 
-                            <div class="col-lg-6 col-sm-12">
 
-                                <button type="button" class="btn btn-light btn-block btn-lg" data-toggle="modal"
-                                        data-target="#listObservers">
-                                    <b>{{ observers|length | pretty }} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}
-                                </button>
+                            {% if configuration.DISPLAY_OBSERVERS %}
+                                <!-- au minimum il y a 1 btn : communes -->
+                                {% set nb_btn = 1 %}
+                                <!-- si on affiche les observateurs : + 1 btn -->
+                                {% if configuration.DISPLAY_OBSERVERS %}{% set nb_btn = nb_btn + 1 %}{% endif %}
+                                
 
-                                <!-- Modal -->
-                                <div id="listObservers" class="modal fade" role="dialog">
-                                    <div class="modal-dialog modal-lg">
+                                {% if nb_btn == 1 %} <div class="col-lg-offset-3 col-lg-6 col-sm-12">
+                                {% elif nb_btn == 2 %} <div class="col-lg-6 col-sm-12">
+                                {% else %} <div class="col-xs-12">
+                                {% endif %}
 
-                                        <!-- Modal content-->
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <button type="button" class="close" data-dismiss="modal">&times;
-                                                </button>
-                                                <h4 class="modal-title"><b>Liste des observateurs du taxon</b></h4>
-                                            </div>
-                                            <div class="modal-body">
-                                                <div class="">
-                                                    {% for o in observers %}
-                                                        {{o }}
-                                                        {% if  not loop.last %}
-                                                        -
-                                                        {% endif %}
-                                                    {% endfor %}
+                                    <button type="button" class="btn btn-light btn-block btn-lg" data-toggle="modal"
+                                            data-target="#listObservers">
+                                        <b>{{ observers|length | pretty }} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}
+                                    </button>
+
+                                    <!-- Modal -->
+                                    <div id="listObservers" class="modal fade" role="dialog">
+                                        <div class="modal-dialog modal-lg">
+
+                                            <!-- Modal content-->
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal">&times;
+                                                    </button>
+                                                    <h4 class="modal-title"><b>Liste des observateurs du taxon</b></h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <div class="">
+                                                        {% for o in observers %}
+                                                            {{o }}
+                                                            {% if  not loop.last %}
+                                                            -
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-default" data-dismiss="modal">
+                                                        Fermer
+                                                    </button>
                                                 </div>
                                             </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">
-                                                    Fermer
-                                                </button>
-                                            </div>
+
                                         </div>
-
                                     </div>
-                                </div>
 
-                            </div>
+                                </div>
+                            {% endif %}
 
                             
                     <!-- Si on veux les infos sous la cartes dans des onglets -->
@@ -393,7 +414,9 @@
                             {% else %}
                             <li class="active"><a data-toggle="tab" href="#communes"> <b>{{communes|length | pretty}}</b> {{ 'communes' if communes|length > 1 else 'commune' }}</a></li>
                             {% endif %}
-                            <li><a data-toggle="tab" href="#observateurs"> <b>{{observers|length | pretty}} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}</a></li>
+                            {% if configuration.DISPLAY_OBSERVERS %}
+                                <li><a data-toggle="tab" href="#observateurs"> <b>{{observers|length | pretty}} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}</a></li>
+                            {% endif %}
                           </ul>
 
                         <div class="tab-content" style="width:100%;">
@@ -456,6 +479,7 @@
                                 </p>
                             </div>
 
+                            {% if configuration.DISPLAY_OBSERVERS %}
                             <div id="observateurs" class="tab-pane fade">
                                 {% for o in observers %}
                                     {{o }}
@@ -464,6 +488,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </div>
+                            {% endif %}
                         </div>
                     {% endif %}
                 </div>

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -493,8 +493,63 @@
                     {% endif %}
                 </div>
             </div>
-        </div>
+            {% if configuration.INFOS_POPUP %}
+              {% if articles | length != 0 %}
+                <div class="panel panel-default" id="otherInformationsPanel">
+                    <div class="row" id="otherInformations">
+                        <div id="articles">
+                        <h4>
+                            <span class="glyphicon glyphicon-file"></span>
+                            <b>{{articles|length | pretty}}</b> {{ 'articles' if articles|length > 1 else 'article' }}
+                        </h4>
+                        <hr class="small-hr">
+                            <table class="table table-striped">
+                                <thead>
+                                    <th> </th>
+                                    <th> Titre </th>
+                                    <th> Auteur </th>
+                                </thead>
+                                <tbody>
 
+                                        {% for i in range (articles | length) %}
+                                            <tr class="accordion-toggle" data-toggle="collapse" data-target=".moreInfo{{i}}">
+                                                <td> {% if articles[i].id_type == 3 %} <span class="glyphicon glyphicon-link"> </span>
+                                                     {% else %} <span class="glyphicon glyphicon-paperclip"> </span>
+                                                     {% endif %}
+                                                </td>
+
+                                                <td>
+                                                    <a href="{{articles[i].path}}" target="_blank"> {{articles[i].title}} </a>
+                                                 </td>
+
+                                                <td>
+                                                    {{articles[i].author}}
+                                                </td>
+                                                <td>
+                                                   <i class="btn-more"> <span class="glyphicon glyphicon-chevron-down "> </span></i>
+                                                </td>
+
+                                            </tr>
+                                            <tr>
+                                                <td colspan ="4" class="hiddenRow" style="padding:0px;">
+                                                    <div  class="collapse moreInfo{{i}}">
+                                                        <strong> Description : </strong> <br> {{articles[i].description | safe}} <br>
+                                                        <strong> Date : </strong> {{articles[i].date}}
+                                                    </div>
+                                                </td>
+                                            </tr>
+
+                                        {% endfor %}
+
+                                </tbody>
+                            </table>
+                        </div>
+
+                    </div>
+                </div>
+              {% endif %}
+            {% endif %}
+        </div>
         <div class="col-lg-5 col-md-5 col-sm-12 col-xs-12">
             {% if photoCarousel | length >= 1 %}
             <div class="panel panel-default">

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -298,14 +298,102 @@
 
             <div class="panel panel-default" id="otherInformationsPanel">
                 <div class="row" id="otherInformations">
+
+                    <!-- Si on veux les infos sous la cartes en pop-up -->
+                    {% if configuration.INFOS_POPUP %}
+
+                            <div class="col-lg-6 col-sm-12">
+
+                                <button type="button" class="btn btn-light btn-block btn-lg" data-toggle="modal"
+                                        data-target="#listCommunes">
+                                    <b>{{ communes|length | pretty }}</b> {{ 'communes' if communes|length > 1 else 'commune' }}
+                                </button>
+
+                                <!-- Modal -->
+                                <div id="listCommunes" class="modal fade" role="dialog">
+                                    <div class="modal-dialog modal-lg">
+
+                                        <!-- Modal content-->
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <button type="button" class="close" data-dismiss="modal">&times;
+                                                </button>
+                                                <h4 class="modal-title"><b>Liste des communes où le taxon a été
+                                                    observé</b></h4>
+                                            </div>
+                                            <div class="modal-body">
+                                                <div class="">
+                                                    {% for com in communes %}
+                                                        <a href="{{ url_for('main.ficheCommune', insee = com.insee) }}">{{ com.commune_maj }}</a>
+                                                        {% if not loop.last %}
+                                                            -
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-default" data-dismiss="modal">
+                                                    Fermer
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+
+                            </div>
+
+                            <div class="col-lg-6 col-sm-12">
+
+                                <button type="button" class="btn btn-light btn-block btn-lg" data-toggle="modal"
+                                        data-target="#listObservers">
+                                    <b>{{ observers|length | pretty }} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}
+                                </button>
+
+                                <!-- Modal -->
+                                <div id="listObservers" class="modal fade" role="dialog">
+                                    <div class="modal-dialog modal-lg">
+
+                                        <!-- Modal content-->
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <button type="button" class="close" data-dismiss="modal">&times;
+                                                </button>
+                                                <h4 class="modal-title"><b>Liste des observateurs du taxon</b></h4>
+                                            </div>
+                                            <div class="modal-body">
+                                                <div class="">
+                                                    {% for o in observers %}
+                                                        {{o }}
+                                                        {% if  not loop.last %}
+                                                        -
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-default" data-dismiss="modal">
+                                                    Fermer
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+
+                            </div>
+
+                            
+                    <!-- Si on veux les infos sous la cartes dans des onglets -->
+                    {% else %}
                           <ul class="nav nav-tabs">
                             {% if articles | length != 0 %}
-                            <li class="active"><a data-toggle="tab" href="#articles"><b>{{articles|length}}</b> {{ 'articles' if articles|length > 1 else 'article' }}</a></li>
-                            <li><a data-toggle="tab" href="#communes"> <b>{{communes|length}}</b> {{ 'communes' if communes|length > 1 else 'commune' }}</a></li>
+                            <li class="active"><a data-toggle="tab" href="#articles"><b>{{articles|length | pretty}}</b> {{ 'articles' if articles|length > 1 else 'article' }}</a></li>
+                            <li><a data-toggle="tab" href="#communes"> <b>{{communes|length | pretty}}</b> {{ 'communes' if communes|length > 1 else 'commune' }}</a></li>
                             {% else %}
-                            <li class="active"><a data-toggle="tab" href="#communes"> <b>{{communes|length}}</b> {{ 'communes' if communes|length > 1 else 'commune' }}</a></li>
+                            <li class="active"><a data-toggle="tab" href="#communes"> <b>{{communes|length | pretty}}</b> {{ 'communes' if communes|length > 1 else 'commune' }}</a></li>
                             {% endif %}
-                            <li><a data-toggle="tab" href="#observateurs"> <b>{{observers|length}} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}</a></li>
+                            <li><a data-toggle="tab" href="#observateurs"> <b>{{observers|length | pretty}} </b> {{ 'observateurs' if observers|length > 1 else 'observateur' }}</a></li>
                           </ul>
 
                         <div class="tab-content" style="width:100%;">
@@ -377,6 +465,7 @@
                                 {% endfor %}
                             </div>
                         </div>
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Pour avoir le choix d'afficher la liste des communes et des observateurs (fiches espèces) soit dans des onglets, soit dans des pop-up via des boutons + pouvoir afficher ou cacher la liste des noms des observateurs.

- **Basé sur le travail de @lpofredc / LPO AURA  (https://framagit.org/lpoaura/geonature/GeoNature-atlas)**
- Affichage des communes et des observateurs dans des pop-up avec le paramètre INFOS_POPUP
- Affichage de la liste des observateurs oui/non avec le paramètre DISPLAY_OBSERVERS

Dans le template des fiches espèces, la taille des boutons pour ouvrir les pop-up contenant les listes (communes, observers) est définies à l'aide de la variables nb_btn :   

```
<!-- au minimum il y a 1 btn : communes -->
{% set nb_btn = 1 %}
<!-- si on affiche les observateurs : + 1 btn -->
{% if configuration.DISPLAY_OBSERVERS %}{% set nb_btn = nb_btn + 1 %}{% endif %}

{% if nb_btn == 1 %} <div class="col-lg-offset-3 col-lg-6 col-sm-12">
{% elif nb_btn == 2 %} <div class="col-lg-6 col-sm-12">
{% else %} <div class="col-xs-12">
{% endif %}
```

On pourrait ensuite ajouter d'autres listes, comme la liste des organismes à l'origine des données, en incrémentant `nb_btn` et en ajoutant une autre mise en forme des boutons (par exemple `{% elif nb_btn == 3 %} <div class="col-lg-4 col-sm-12">`)

