### PR TITLE
unaccent group_2inpn

### DIFF
--- a/atlas/modeles/repositories/vmObservationsRepository.py
+++ b/atlas/modeles/repositories/vmObservationsRepository.py
@@ -318,7 +318,7 @@ def getLastDiscoveries(connection):
             'nom_vern':r.nom_vern,
             'lb_nom':r.lb_nom,
             'id_media':r.id_media,
-            'group2_inpn': r.group2_inpn,
+            'group2_inpn': utils.deleteAccent(r.group2_inpn),
             'media_path': r.chemin if r.chemin is not None else r.url
         }
         lastDiscoveriesList.append(temp)


### PR DESCRIPTION
Enlever les accents des group2_inpn des "LastDiscoveries" pour l'affichage correct des pictos quand les group2inpn ont des accents (par ex. Mammifères)