### PR TITLE
Affichage des photos des taxons

### DIFF
--- a/atlas/templates/organismSheet/topSpecies.html
+++ b/atlas/templates/organismSheet/topSpecies.html
@@ -19,7 +19,7 @@
                             {% if configuration.REDIMENSIONNEMENT_IMAGE %}
                                 {% set img_path = configuration.TAXHUB_URL+'/api/tmedias/thumbnail/'+ taxon.photo.id_media|string+'?h=100&w=150' %}
                             {% else %}
-                                {% set img_path = taxon.photo.path %}
+                                {% set img_path = configuration.REMOTE_MEDIAS_URL+taxon.photo.path %}
                             {% endif %}
                             <img class="mainImg" src="{{img_path}}"
                                 style='width:100px'>


### PR DESCRIPTION
Les photos des taxons sur les fiches des organismes n'étaient pas affichées dans le cas où REDIMENSIONNEMENT_IMAGE = False.
Les pictos et les images redimensionnées sont OK.