### PR TITLE
Affichage des organismes

### DIFF
--- a/atlas/atlasRoutes.py
+++ b/atlas/atlasRoutes.py
@@ -114,6 +114,7 @@ if config["ORGANISM_MODULE"]:
             tel_organism=infos_organism["tel_organism"],
             url_organism=infos_organism["url_organism"],
             url_logo=infos_organism["url_logo"],
+            email_organism=infos_organism["email_organism"],
             nb_taxons=infos_organism["nb_taxons"],
             nb_obs=infos_organism["nb_obs"],
             stat=stat,

--- a/atlas/modeles/repositories/vmOrganismsRepository.py
+++ b/atlas/modeles/repositories/vmOrganismsRepository.py
@@ -35,7 +35,7 @@ def statOrganism (connection,id_organism):
 
 def topObsOrganism(connection, id_organism):
     #Stats avancées organism
-    sql = """SELECT cd_ref, nb_observations as nb_obs 
+    sql = """SELECT cd_ref, nb_observations as nb_obs_taxon 
     FROM atlas.vm_cor_taxon_organism o
     WHERE o.id_organism = :thisidorganism
     ORDER BY nb_observations DESC
@@ -46,7 +46,7 @@ def topObsOrganism(connection, id_organism):
     for r in req:
         temp={
             'cd_ref':r.cd_ref,
-            'nb_obs':r.nb_obs,
+            'nb_obs_taxon':r.nb_obs_taxon,
         }
         topSpecies.append(temp)
     return topSpecies

--- a/atlas/modeles/repositories/vmOrganismsRepository.py
+++ b/atlas/modeles/repositories/vmOrganismsRepository.py
@@ -54,11 +54,15 @@ def topObsOrganism(connection, id_organism):
 
 
 def getListOrganism(connection,cd_ref):
-    # Fiche espèce : Liste des organisms pour un taxon
-    sql = """SELECT nb_observations, id_organism, nom_organism, url_organism, url_logo
-    FROM atlas.vm_cor_taxon_organism o 
-    WHERE cd_ref = :thiscdref
-    ORDER BY nb_observations DESC"""
+    # Fiche espèce : Liste des organismes pour un taxon
+    sql = """SELECT SUM(nb_observations) AS nb_observations, id_organism, nom_organism, url_organism, url_logo
+             FROM atlas.vm_cor_taxon_organism o 
+             WHERE cd_ref in (
+                SELECT * FROM atlas.find_all_taxons_childs(:thiscdref)
+                )
+                OR cd_ref = :thiscdref
+             GROUP by id_organism, nom_organism, url_organism, url_logo            
+             ORDER BY nb_observations DESC"""
     req = connection.execute(text(sql), thiscdref=cd_ref)
     ListOrganism=list()
     for r in req:

--- a/atlas/static/css/ficheEspece.css
+++ b/atlas/static/css/ficheEspece.css
@@ -112,7 +112,7 @@ p.imgDescription.main {
 }
 
 #map {
-  height: 600px;
+  height: 650px;
 }
 
 #loadingGif {

--- a/atlas/templates/organismSheet/_main.html
+++ b/atlas/templates/organismSheet/_main.html
@@ -33,7 +33,8 @@
             <div class="col-lg-5 col-md-5 col-sm-12 col-xs-12">
                 {% include 'templates/organismSheet/topSpecies.html' %}
                 {% include 'templates/organismSheet/groupChart.html' %}
-                {% include 'templates/organismSheet/blocInfos.html' %}
+                <!--TODO : faire remontées des infos 'autres'-->
+                {#% include 'templates/organismSheet/blocInfos.html' %#}
             </div>
         </div>
     </div>

--- a/atlas/templates/organismSheet/_main.html
+++ b/atlas/templates/organismSheet/_main.html
@@ -1,6 +1,7 @@
 {% extends "templates/core/layout.html" %}
 
     {% block title %}
+    {{ nom_organism }}
     {% endblock %}
 
     {% block additionalHeaderAssets %}

--- a/atlas/templates/organismSheet/identityCard.html
+++ b/atlas/templates/organismSheet/identityCard.html
@@ -3,15 +3,14 @@
 		<div class=" card-body row" id="rowIdentity">
 			<!-- Logo -->
 			{% if url_logo != none %}
-			<div class="imgWrapper  left">				
-				<a href="{{ url_organism }}" data-lightbox="imageSet">
-					
-					<img id="mainImg" 
-					src='{{ url_logo }}'
-					style="width: 200px;">
-					
+			<div class="imgWrapper left">
+				{% if url_organism|length > 9 %}
+				<a href="{{ url_organism }}" target="_blank">
+					<img id="mainImg" src='{{ url_logo }}' style="width: 200px;">
 				</a>
-				
+				{% else %}
+					<img id="mainImg" src='{{ url_logo }}' style="width: 200px;">
+				{% endif %}
 			</div>
 			{% endif %}
 			<div class="left col-9  ">

--- a/atlas/templates/organismSheet/identityCard.html
+++ b/atlas/templates/organismSheet/identityCard.html
@@ -20,6 +20,9 @@
 				<br><b>{{ _('Adresse') }}</b> : {{ adresse_organism}}, {{ cp_organism }} {{ ville_organism }}
 				<br><b>{{ _('Téléphone') }}</b> : {{ tel_organism }}
 				<br><b>{{ _('Email') }}</b> : {{ email_organism }}
+				{% if url_organism|length > 9 %}
+					<br><b>{{ _('Site') }}</b> : <a href="{{ url_organism }}" target="_blank">{{ url_organism }}</a>
+				{% endif %}
 			</div>
 		</div>
 	</div>

--- a/atlas/templates/organismSheet/identityCard.html
+++ b/atlas/templates/organismSheet/identityCard.html
@@ -20,9 +20,7 @@
 				<br><b>{{ _('Adresse') }}</b> : {{ adresse_organism}}, {{ cp_organism }} {{ ville_organism }}
 				<br><b>{{ _('Téléphone') }}</b> : {{ tel_organism }}
 				<br><b>{{ _('Email') }}</b> : {{ email_organism }}
-				{% if url_organism|length > 9 %}
-					<br><b>{{ _('Site') }}</b> : <a href="{{ url_organism }}" target="_blank">{{ url_organism }}</a>
-				{% endif %}
+				<br><b>{{ _('Site') }}</b> : <a href="{{ url_organism }}" target="_blank">{{ url_organism }}</a>
 			</div>
 		</div>
 	</div>

--- a/atlas/templates/organismSheet/identityCard.html
+++ b/atlas/templates/organismSheet/identityCard.html
@@ -18,8 +18,9 @@
 			<h1>
 				<strong>{{ nom_organism }}</strong>
 			</h1>
-				<br><b>{{ _('Adresse') }}</b> : {{ adresse_organism}} {{ cp_organism }}
+				<br><b>{{ _('Adresse') }}</b> : {{ adresse_organism}}, {{ cp_organism }} {{ ville_organism }}
 				<br><b>{{ _('Téléphone') }}</b> : {{ tel_organism }}
+				<br><b>{{ _('Email') }}</b> : {{ email_organism }}
 			</div>
 		</div>
 	</div>

--- a/atlas/templates/organismSheet/topSpecies.html
+++ b/atlas/templates/organismSheet/topSpecies.html
@@ -53,11 +53,11 @@
                                 {{ taxon.nom_vern.split(',')[0].strip() }}
                             {% endif %}</b></h5>
                         <h5>
-                            <span id="name italic">{{ taxon.lb_nom|safe }}</span>
+                            <i>{{ taxon.lb_nom|safe }}</i>
                         </h5>
 
                         <b>
-                            {{ taxon['nb_obs']}} </b>
+                            {{ taxon['nb_obs_taxon']}} </b>
                             {% if taxon.nb_obs == 1 %}{{_ ('observation')}}{% else %}{{_ ('observations')}}{% endif %} <br>
                         <b>{{ "%.2f"|format(taxon['nb_obs'] / nb_obs*100) }}% </b>{{ _('from.organism.observations') }}
                         <span class="float-right">

--- a/atlas/templates/organismSheet/topSpecies.html
+++ b/atlas/templates/organismSheet/topSpecies.html
@@ -58,8 +58,8 @@
 
                         <b>
                             {{ taxon['nb_obs_taxon']}} </b>
-                            {% if taxon.nb_obs == 1 %}{{_ ('observation')}}{% else %}{{_ ('observations')}}{% endif %} <br>
-                        <b>{{ "%.2f"|format(taxon['nb_obs'] / nb_obs*100) }}% </b>{{ _('from.organism.observations') }}
+                            {% if taxon['nb_obs_taxon'] == 1 %}{{_ ('observation')}}{% else %}{{ _('observations')}}{% endif %} <br>
+                        <b>{{ "%.2f"|format(taxon['nb_obs_taxon'] / taxon['nb_obs_taxon']*100) }}% </b>{{ _('from.organism.observations') }}
                         <span class="float-right">
                         <a class="badge badge-primary" href="{{ url_for('main.ficheEspece', cd_nom=taxon['cd_ref']) }}"
                            data-toggle="tooltip"
@@ -67,7 +67,6 @@
                             <i class="fas fa-list fa-fw"></i> {{ _('species.sheet') }}</i>
                         </a>
                         </span>
-
                     </div>
                 {% endfor %}
             </ul>

--- a/atlas/templates/speciesSheet/map.html
+++ b/atlas/templates/speciesSheet/map.html
@@ -23,6 +23,11 @@
                         <i class="fas fa-users fa-2x"></i> <br/>
                         <b>{{ observers|length|pretty }}</b> <br/>
                         <span style="font-size: 0.90rem">{{ _('observers')|lower if observers|length > 1 else _('observer')|lower }}</span>
+                        {% if configuration.ORGANISM_MODULE %}
+                        <br/>
+                        <b>{{ organisms|length }} </b> <br/>
+                        <span style="font-size: 0.90rem">{{ _('organisms')|lower if organisms|length > 1 else _('organism')|lower }}</span>
+                        {% endif %}
                     </li>
                     <li id="firstObs" class="pointer">
                         <i class="fas fa-search fa-2x"></i> <br/>

--- a/atlas/templates/speciesSheet/otherInformations.html
+++ b/atlas/templates/speciesSheet/otherInformations.html
@@ -118,13 +118,15 @@
                                     <span class="float-right"></span>
                                     <div class="pictoImgList mr-2" data-toggle="tooltip" data-original-title="{{ taxon.group2_inpn }}"
                                     data-placement="right">
-                                        <a href="{{ o['url_organism'] }}" target="_blank">
-                                            {% if o['url_logo']!= None %}
-                                            <img class="mx-auto d-block"
-                                            src="{{ o['url_logo'] }}" style='width:100px'
-                                            >
+                                        {% if o['url_logo']!= None %}
+                                            {% if o['url_organism']|length > 9 %}
+                                            <a href="{{ o['url_organism'] }}" target="_blank">
+                                                <img class="mx-auto d-block" src="{{ o['url_logo'] }}" style='width:100px'>
+                                            </a>
+                                            {% else %}
+                                                <img class="mx-auto d-block" src="{{ o['url_logo'] }}" style='width:100px'>
                                             {% endif %}
-                                        </a>
+                                        {% endif %}
                                     </div>
                                 </div>
                                 

--- a/atlas/templates/speciesSheet/otherInformations.html
+++ b/atlas/templates/speciesSheet/otherInformations.html
@@ -14,7 +14,7 @@
                         <b>{{ communes|length }}</b> {{ _('municipalities')|lower if communes|length > 1 else _('municipality')|lower }}</a>
                     </li>
                 {% endif %}
-                
+
                 {% if config.ORGANISM_MODULE %}
                     <li class="nav-item">
                         <a class="nav-link" {% if not configuration.ANONYMIZE %}data-toggle="tab"
@@ -30,7 +30,7 @@
                 </a></li>
             </ul>
 
-           
+
             <div class="tab-content" style="width:100%;">
                  <!-- municipality tab-->
                 {% if articles | length != 0 %}
@@ -105,13 +105,13 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-        
+
                 {% if configuration.ORGANISM_MODULE %}
                 <!-- organism tab -->
                     <div id="organisms" class="tab-pane fade flex-grow-1">
                         <ul class="list-group w-100">
                             {% for o in organisms %}
-                                <li id="organismListItem" class="media border-bottom p-2" 
+                                <li id="organismListItem" class="media border-bottom p-2"
                                     id_organism="{{ o['nom_organism'] }}">
                                 <div class="pictoImgList mr-2" data-toggle="tooltip" data-original-title="{{ taxon.group2_inpn }}"
                                  data-placement="right">
@@ -119,7 +119,7 @@
                                     <div class="pictoImgList mr-2" data-toggle="tooltip" data-original-title="{{ taxon.group2_inpn }}"
                                     data-placement="right">
                                         {% if o['url_logo']!= None %}
-                                            {% if o['url_organism']|length > 9 %}
+                                            {% if not o['url_organism'] in (None, '') %}
                                             <a href="{{ o['url_organism'] }}" target="_blank">
                                                 <img class="mx-auto d-block" src="{{ o['url_logo'] }}" style='width:100px'>
                                             </a>
@@ -129,25 +129,32 @@
                                         {% endif %}
                                     </div>
                                 </div>
-                                
+
                                 <div class="media-body">
                                     <span class="float-right"></span>
                                     <h5 class="mt-0 mb-1 ">
                                         <span id="name"><b>{{ o['nom_organism'] }}</b></span>
                                     </h5>
 
-                                    <strong>{{ _('organism.participation') }} {{ o['nb_observation']}} {{ _('observations') }}</strong>
+                                    <strong>{{ _('organism.participation') }}
+                                        {{ o['nb_observation']}}
+                                        {% if o['nb_observation'] > 1 %}
+                                            {{ _('observations') }}
+                                        {% else %}
+                                            {{ _('observation') }}
+                                        {% endif %}
+                                    </strong>
                                     <br>{{ _('organism.prospection') }} : <strong>{{ "%.2f"|format(o['nb_observation']/taxon.taxonSearch.nb_obs*100) }} %</strong>
                                     <br>
                                     <br>
-                                    <span class="float-right">   
+                                    <span class="float-right">
                                         <h3><a class="badge badge-primary" href="{{ url_for('main.ficheOrganism', id_organism=o['id_organism']) }}"
                                             data-toggle="tooltip"  style="color: white;"
                                             title="{{ _('check.organism.sheet') }}" data-placement="left">
                                          <i class="fas fa-list fa-fw"></i> {{ _('organism.sheet') }}</i>
                                         </a></h3>
                                     </span>
-                                    
+
                                 </div>
                             {% endfor %}
                         </ul>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ CHANGELOG
 
 🐛 **Corrections**
 - Corrections linguistiques #383 (par @Splendens)
+- Corrections affichage des organismes #384 (par @Splendens)
 
 1.5.1 (2021-12-06)
 ------------------


### PR DESCRIPTION
**Corrections**

Correction du lien vers le site de l'organisme au clic sur le logo : sur les fiches orga, ça essayait d'ouvrir le logo en grand au lieu de suivre le lien ; dans la liste des orgas sous la carte des fiches espèces, si pas d'url renseignée, ça réouvrait la page courante.

Correction des 3 taxons les plus observés par l'orga dans la fiche organisme : le nombre d'observations affiché par taxon n'était pas le bon.

J'ai aussi commenté le bloc "autre information" de la fiche organisme vu qu'il s'agit pour le moment d'une coquille vide (aucune donnée remontée, le template n'affiche qu'un titre).

-----------------

**Améliorations**

Complétion des renseignements de contact sur l'organisme
![Capture_affichage_orga_atlas_info_orga](https://user-images.githubusercontent.com/19465859/152338429-7d750e55-c46d-4de5-b56a-02c3e8667d57.PNG)

-------------

Ajout du nombre d'organismes à l'origine des données dans la partie de stat à droite de la carte des fiches espèces, au même titre que le nombre d'observateurs
![Capture_affichage_orga_atlas_stat_map](https://user-images.githubusercontent.com/19465859/152338288-ef9acdaf-9c53-46b5-82a5-b1ab0ffd6f86.PNG)


