### PR TITLE
fix(translations): fix typo errors

### DIFF
--- a/atlas/templates/core/listTaxons.html
+++ b/atlas/templates/core/listTaxons.html
@@ -47,7 +47,7 @@
                                                                target="_blank">
                                     <img src="{{ url_for('static', filename='images/logo_protection.png') }}"
                                          style="width : 30px; height: 30px" data-placement="left" data-toggle="tooltip"
-                                         data-original-title="{{ ('this.taxon.has.a.protected.status') }}">
+                                         data-original-title="{{ _('this.taxon.has.a.protected.status') }}">
                                                 </a>
                                                    {% endif %}
                                                {% endif %}

--- a/atlas/templates/core/tabTaxons.html
+++ b/atlas/templates/core/tabTaxons.html
@@ -57,7 +57,7 @@
                                    target="_blank">
                                     <img src="{{ url_for('static', filename='images/logo_protection.png') }}"
                                          style="width : 40px; height: 40px" data-placement="left" data-toggle="tooltip"
-                                         data-original-title={{ _('this.taxon.has.a.protected.status') }}>
+                                         data-original-title="{{ _('this.taxon.has.a.protected.status') }}">
                                 </a>
                             {% endif %}
                         </td>

--- a/atlas/templates/organismSheet/topSpecies.html
+++ b/atlas/templates/organismSheet/topSpecies.html
@@ -33,7 +33,7 @@
                                     target="_blank">
                                     <img src="{{ url_for('static', filename='images/logo_protection.png') }}"
                                     style="width : 30px; height: 30px;" data-placement="left" data-toggle="tooltip"
-                                    data-original-title="{{ ('this.taxon.has.a.protected.status') }}">
+                                    data-original-title="{{ _('this.taxon.has.a.protected.status') }}">
                                 </a>
                             {% endif %}
                         {% endif %}


### PR DESCRIPTION
Bonjour,

Quelques corrections mineures suite à l'utilisation du module PROTECTION pour le Golfe du Morbihan.

Ces corrections permettent de prendre en compte les traductions sur la page Organisme et Commune lorsqu'on passe la souris sur l'icône de protection : 
**Avant :** 
![image](https://user-images.githubusercontent.com/85738261/173335186-ea6ba8e1-a472-4aca-95c4-20dd6d9c72fb.png)

**Après :**
![image](https://user-images.githubusercontent.com/85738261/173334979-8935799e-1ccf-4789-81dc-134879111773.png)

