### PR TITLE
Feat/auto reload templates

### DIFF
--- a/atlas/configuration/config.py.example
+++ b/atlas/configuration/config.py.example
@@ -15,6 +15,9 @@ database_connection = "postgresql://user:monpassachanger@IPADRESSE:5432/database
 # Port sur lequel tourne le serveur gunicorn
 GUNICORN_PORT = 8080
 
+# Recharger automatiquement les templates
+TEMPLATES_AUTO_RELOAD = False
+
 #################################
 #################################
 ### Customisation application ###

--- a/atlas/configuration/config.py.sample
+++ b/atlas/configuration/config.py.sample
@@ -9,6 +9,9 @@
 # eventuellement le port de la BDD et le nom de la BDD avec l'utilisateur qui a des droits de lecture sur les vues de l'atlas (user_pg dans settings.ini)
 database_connection = "postgresql://user:monpassachanger@IPADRESSE:5432/databaseName"
 
+# Recharger automatiquement les templates
+TEMPLATES_AUTO_RELOAD = False
+
 #################################
 #################################
 ### Customisation application ###

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -205,6 +205,10 @@ class AtlasConfig(Schema):
     SPLIT_NOM_VERN = fields.Boolean(load_default=True)
     INTERACTIVE_MAP_LIST = fields.Boolean(load_default=True)
     AVAILABLE_LANGUAGES = fields.Dict(load_default=LANGUAGES)
+    # Flask parameter enabling auto reload of templates 
+    # (no need to restart the atlas service when updating templates)
+    # Defaults to False to have the best performance in production
+    TEMPLATES_AUTO_RELOAD = fields.Boolean(load_default=False)
 
     @validates_schema
     def validate_url_taxhub(self, data, **kwargs):


### PR DESCRIPTION
Bonjour,

Comme mentionné dans #431, ajout de la possibilité de recharger les templates automatiquement sans avoir à relancer le service geonature-atlas.

Utilise le paramètre `TEMPLATES_AUTO_RELOAD` de Flask : https://flask.palletsprojects.com/en/2.1.x/config/?highlight=templates_auto_reload#TEMPLATES_AUTO_RELOAD

Pour obtenir les meilleures performances en production, ce paramètre est mis à `False` par défaut.