### PR TITLE
Fix: Scroll sur la liste d'espèce dans une fiche commune

### DIFF
--- a/atlas/static/listeEspeces.js
+++ b/atlas/static/listeEspeces.js
@@ -1,7 +1,8 @@
 $(".lazy").lazy({
           effect: "fadeIn",
           effectTime: 2000,
-          threshold: 0
+          threshold: 0,
+          appendScroll: $("#taxonList")
         });
 $('[data-toggle="tooltip"]').tooltip();
 $(document).ready(function(){


### PR DESCRIPTION
Bonjour,

L'objectif de cette PR est de réparer un problème d'affichage de photo lors du scroll sur la liste d'espèce sur la fiche commune. 
En effet, si la liste contient plusieurs espèces, leur photo n'apparaissaient pas en la déroulant.
Cela est dû à un oubli d'un paramètre ici : https://github.com/PnX-SI/GeoNature-atlas/blob/a6fa2faa029b32d928883351832e44127ca4aa91/atlas/static/listeEspeces.js#L1-L5

Il suffit d'ajouter : `appendScroll: $("#taxonList")` pour que jQuery observe le comportement de la scroll bar rattachée à l'élément d'id `taxonList`