### PR TITLE
fix: remove legend generator when slider clicked

### DIFF
--- a/atlas/static/mapGenerator.js
+++ b/atlas/static/mapGenerator.js
@@ -213,6 +213,10 @@ function styleMaille(feature) {
 }
 
 function generateLegendMaille() {
+  // check if contour already exists
+  if (L.DomUtil.get("contour-legend")) {
+    return
+  }
   legend.onAdd = function (map) {
     var div = L.DomUtil.create("div", "info legend"),
       grades = [0, 1, 2, 5, 10, 20, 50, 100],
@@ -228,6 +232,8 @@ function generateLegendMaille() {
           (grades[i + 1] ? "&ndash;" + grades[i + 1] + "<br>" : "+")
       );
     }
+    // Add id to get it above
+    div.id = "contour-legend"
     div.innerHTML = labels.join("<br>");
 
     return div;

--- a/atlas/static/mapGenerator.js
+++ b/atlas/static/mapGenerator.js
@@ -130,17 +130,17 @@ function generateMap(zoomHomeButton) {
   fullScreenButton.attr("data-toggle", "tooltip");
   fullScreenButton.attr("data-original-title", "Fullscreen");
   $(".leaflet-control-fullscreen-button").removeAttr("title");
-  
+
   // Add scale depending on the configuration
   if (configuration.MAP.ENABLE_SCALE) {
     L.control.scale(
       {
-        imperial: false, 
+        imperial: false,
         position: 'bottomright'
       }
       ).addTo(map);
   }
-  
+
   return map;
 }
 
@@ -224,12 +224,11 @@ function generateLegendMaille() {
 
     // loop through our density intervals and generate a label with a colored square for each interval
     for (var i = 0; i < grades.length; i++) {
+      grade_n1 = grades[i + 1] ? `&ndash; ${grades[i + 1] } <br>` : "+"
       labels.push(
-        '<i style="background:' +
-          getColor(grades[i] + 1) +
-          '"></i> ' +
-          grades[i] +
-          (grades[i + 1] ? "&ndash;" + grades[i + 1] + "<br>" : "+")
+        `<i style="background: ${getColor(grades[i] + 1)}"></i>
+          ${grades[i]}${grade_n1}
+        `
       );
     }
     // Add id to get it above
@@ -436,7 +435,7 @@ function onEachFeaturePointLastObs(feature, layer) {
     popupContent +
       "</br> <a href='" +
       configuration.URL_APPLICATION +
-      
+
       language +
       "/espece/" +
       feature.properties.cd_ref +
@@ -585,7 +584,7 @@ function styleMailleLastObs() {
 }
 
 function generateGeoJsonMailleLastObs(observations) {
-  // sort it because at each change of idMaille, the 
+  // sort it because at each change of idMaille, the
   // list_taxon is reset so not all species are displayed
   observations = observations.sort((a,b) => compare(a, b))
   var i = 0;

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ CHANGELOG
 - Page principale (Affichage par maille) scroll sur la liste des taxons #451 (par @mvergez)
 - Prise en compte des cas ou le srid est différent de 2154 #417 (par @joelclems)
 - Harmonisation de l'affichage du picto group2_inpn #424, #425, #426, #427, #429 (par @MissT)
+- Afficage en double de la légende quand le slider était touché #452 (par @mvergez)
 
 ⚠️ **Notes de version**
 


### PR DESCRIPTION
# Contexte

Lorsque, dans une fiche espèce, le slider était touché, la légende apparaissait 2 fois : 
![image](https://user-images.githubusercontent.com/85738261/204257978-807dc175-24ca-41d7-acc6-89179c9c2526.png)

Cette PR corrige ce problème en vérifiant si cette légende est déjà insérée

avec @andriacap