### PR TITLE
Revert "Bump minimist from 1.2.5 to 1.2.8 in /atlas/static"

### DIFF
--- a/atlas/static/package-lock.json
+++ b/atlas/static/package-lock.json
@@ -2523,9 +2523,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "ms": {


### PR DESCRIPTION
Reverts PnX-SI/GeoNature-atlas#465