### PR TITLE
Correction légende photo principale identityCard.html

### DIFF
--- a/atlas/templates/speciesSheet/identityCard.html
+++ b/atlas/templates/speciesSheet/identityCard.html
@@ -17,7 +17,7 @@
                             <img id="mainImg" src="{{ img_path }}"
                                  style="width:100%;"
                                  alt="{{ firstPhoto.title }} &copy; {{ firstPhoto.author|striptags }}">
-                            <p class="imgDescription main">{{ firstPhoto.title }}
+                            <p class="imgDescription main">{{ firstPhoto.title|safe }}
                                 {% if firstPhoto.description %}
                                     - {{ firstPhoto.description }}
                                 {% endif %}


### PR DESCRIPTION
Fixe le problème de titre dans la légende de la photo principale de l'espèce : balises <i></i> de title affichées au lieu d'être interprétées