### PR TITLE
BUG : pas d'affichage cartographique sur la page "/recherche"

### DIFF
--- a/atlas/templates/core/advanced_search.html
+++ b/atlas/templates/core/advanced_search.html
@@ -266,7 +266,7 @@
                         }
                     }).done(function (observations) {
                         var geoJsonDatas = observations;
-                        if (observations['features'][0]['geometry']['type'] != 'point') {
+                        if ((observations['features'][0]['geometry']['type']).toLowerCase() != 'point') {
                             polygonLayerToCentroid(geoJsonDatas);
                         }
                         //var color = getRandomColor();


### PR DESCRIPTION
Après avoir sélectionné un taxon, la localisation des taxons quand la géométrie est de type point ne s'affichait pas sur la carte.