### PR TITLE
Correction tri gallerie photo

### DIFF
--- a/atlas/static/galleryPhoto.js
+++ b/atlas/static/galleryPhoto.js
@@ -91,16 +91,14 @@ function scrollEvent(photos) {
 
 // ORDER event
 function orderPhotosEvent(photos) {
-  $("body").on("click", "#sort", function() {
+  $("body").on("click", "#order-sort", function () {
     $("#searchPhotos").val("");
 
-    span = $("#orderPhotos").find("span");
-    $(span)
-      .toggleClass("fas fa-sort")
-      .toggleClass("fas fa-random");
-    $(span).attr("id", "random");
+    span = $("#order-sort");
+    $("#order-picto").toggleClass("fas fa-sort").toggleClass("fas fa-random");
+    $(span).attr("id", "order-random");
     $(span).attr("data-original-title", "Trier de manière aléatoire");
-    sortedPhotos = photos.slice().sort(function(a, b) {
+    sortedPhotos = photos.slice().sort(function (a, b) {
       if (a.nb_obs >= b.nb_obs) return -1;
       if (a.nb_obs < b.nb_obs) return 1;
       return 0;
@@ -119,14 +117,12 @@ function orderPhotosEvent(photos) {
 }
 
 function sufflePhotosEvent(photos) {
-  $("body").on("click", "#random", function() {
+  $("body").on("click", "#order-random", function () {
     $("#searchPhotos").val("");
 
-    span = $("#orderPhotos").find("span");
-    $(span)
-      .toggleClass("fas fa-sort")
-      .toggleClass("fas fa-random");
-    $(span).attr("id", "sort");
+    span = $("#order-random");
+    $("#order-picto").toggleClass("fas fa-sort").toggleClass("fas fa-random");
+    $(span).attr("id", "order-sort");
     $(span).attr(
       "data-original-title",
       "Trier les photos par nombre d'observations"

--- a/atlas/templates/photoGalery/_main.html
+++ b/atlas/templates/photoGalery/_main.html
@@ -67,9 +67,9 @@
                         </li>
                         <li class="floatLeft bottom">
                         <span id="orderPhotos" class="sortedButton">
-                            <span id="sort" class="fas fa-sort" data-toggle="tooltip"
+                            <span id="order-sort"  data-toggle="tooltip"
                                   data-original-title="{{ _('order.photos') }}"
-                                  data-placement="top"></span>
+                                  data-placement="top"><span id="order-picto" class="fas fa-sort"></span></span>
                         </span>
                         </li>
                         <li class="floatLeft bottom">

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,7 @@ CHANGELOG
 - Support des cd_ref négatifs
 - Affichage cartographique sur la page "Recherche avancée" (#486)
 - Correction du lien vers les fiches espèces dans la galerie photo (#459 par @jpm-cbna)
+- Correction du bouton de tri (aléatoire ou nombre d'observation) dans la gallerie photo
 
 🐛 **Optimisations**
 


### PR DESCRIPTION
Correction du bouton de tri de la gallerie photo qui ne changeait pas de comportement (tri par nb d'observation vs tri aléatoire