### PR TITLE
feat: add matomo tracking site

### DIFF
--- a/atlas/atlasRoutes.py
+++ b/atlas/atlasRoutes.py
@@ -204,6 +204,11 @@ def index():
     else:
         lastDiscoveries = []
 
+    if current_app.config["MATOMO_URL"] != "":
+        matomo_script = current_app.config["MATOMO_SCRIPT"]
+    else:
+        matomo_script = ""
+
     connection.close()
     session.close()
 
@@ -213,6 +218,7 @@ def index():
         mostViewTaxon=mostViewTaxon,
         customStatMedias=customStatMedias,
         lastDiscoveries=lastDiscoveries,
+        matomo_script=matomo_script,
     )
 
 

--- a/atlas/configuration/config.py.example
+++ b/atlas/configuration/config.py.example
@@ -87,6 +87,11 @@ LANGUAGES = {
 # Code de suivi des statistiques Google Analytics (si AFFICHAGE_FOOTER = True)
 ID_GOOGLE_ANALYTICS = "UA-xxxxxxx-xx"
 
+# Suivi de statistiques avec MATOMO si MATOMO_URL != ""
+MATOMO_URL = "" # URL lié à votre MATOMO
+MATOMO_SITE_ID = 1 # id du site suivi qui correspond ici à celui du GeoNature Atlas (votre site doit être renseigné dans MATOMO)
+#### LIEN AIDE MATOMO : https://developer.matomo.org/guides/tracking-javascript-guide
+
 # Utiliser et afficher le glossaire (static/custom/glossaire.json.sample)
 GLOSSAIRE = False
 

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -77,6 +77,21 @@ LANGUAGES = {
     },
 }
 
+# LATEST VERSION OF MATOMO
+MATOMO_SCRIPT_TO_INCLUDE = """
+  var _paq = _paq || [];
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//url_matomo/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', site_id]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+"""
+
 
 class SecretSchemaConf(Schema):
     class Meta:
@@ -208,6 +223,9 @@ class AtlasConfig(Schema):
     # (no need to restart the atlas service when updating templates)
     # Defaults to False to have the best performance in production
     TEMPLATES_AUTO_RELOAD = fields.Boolean(load_default=False)
+    MATOMO_SCRIPT = fields.String(load_default=MATOMO_SCRIPT_TO_INCLUDE)
+    MATOMO_URL = fields.String(load_default="")
+    MATOMO_SITE_ID = fields.Integer(load_default=0)
 
     @validates_schema
     def validate_url_taxhub(self, data, **kwargs):

--- a/atlas/templates/core/layout.html
+++ b/atlas/templates/core/layout.html
@@ -15,6 +15,19 @@
     {% endblock %}
     <link rel="stylesheet" href="{{ url_for('static', filename='custom/custom.css') }}"/>
     {% block metaTags %}{% endblock %}
+
+    {% if configuration.MATOMO_URL and configuration.MATOMO_SITE_ID is defined %}
+    {% set site_id = configuration.MATOMO_SITE_ID | int(default=-1) %}
+    {% set url_matomo = configuration.MATOMO_URL %}
+        <!-- Matomo -->
+        <script type="text/javascript">
+            var url_matomo = "{{ url_matomo }}";
+            var site_id = {{ site_id | int }};
+            {{ matomo_script | safe }}
+        </script>
+        <!-- End Matomo Code -->
+    {% endif %}
+
 </head>
 
 <body>


### PR DESCRIPTION

Cette PR fait référence aux souhaits de certaines personnes de vouloir utiliser une alternative à Google analytics et notamment MATOMO (anciennement PIWIK).

La proposition faite ici est de donner la possibilité de renseigner les deux pramètres nécessaires à l'utilisation de MATOMO (basé sur l'aide de la dernière version en ligne de matomo voir lien ici -> https://developer.matomo.org/guides/tracking-javascript-guide) 

Les deux paramètres que l'utilisateur doit renseigner concernent l'url du matomo et l'id du site à suivre ( il faut donc au préalable que l'utilisateur renseignr son GeoNature-Atlas dans Matomo,  ce qui lui attribuera un id).

En lien avec les remarques faites dans l'issue #499 , il est possible de surcoucher le script de matomo en paramètre également  ( notamment si le script est amené à être différent entre les versions de matomo ... ). Ce dernier point est peut être à discuter ?

Et bien évidemment, toutes suggestions d'améliorations, remarques sont les bienvenus

Merci d'avance pour vos retours

[Refs_issues] : #499 