### PR TITLE
Ajout des statuts de protection aux fiches espèces

### DIFF
--- a/atlas/atlasRoutes.py
+++ b/atlas/atlasRoutes.py
@@ -31,6 +31,7 @@ from atlas.modeles.repositories import (
     vmMedias,
     vmCorTaxonAttribut,
     vmTaxonsMostView,
+    vmStatutBdcRepository,
 )
 
 

--- a/atlas/configuration/config.py.example
+++ b/atlas/configuration/config.py.example
@@ -270,6 +270,15 @@ STATIC_PAGES = {
 
 ###########################
 ###########################
+######### STATUTS #########
+###########################
+###########################
+
+LIST_STATUS = ['LRE', 'LRN', 'LRNh', 'LRNm', 'LRNn', 'LRNp', 'LRR', 'LRRm', 'LRRn']
+GEO_STATUS = ['France', 'France métropolitaine', 'Bretagne', 'Côtes-d''Armor', 'Finistère', 'Morbihan', 'Ille-et-Vilaine']
+
+###########################
+###########################
 #### Security  Config #####
 ###########################
 ###########################

--- a/atlas/configuration/config.py.example
+++ b/atlas/configuration/config.py.example
@@ -274,8 +274,8 @@ STATIC_PAGES = {
 ###########################
 ###########################
 
-LIST_STATUS = ['LRE', 'LRN', 'LRNh', 'LRNm', 'LRNn', 'LRNp', 'LRR', 'LRRm', 'LRRn']
-GEO_STATUS = ['France', 'France métropolitaine', 'Bretagne', 'Côtes-d''Armor', 'Finistère', 'Morbihan', 'Ille-et-Vilaine']
+LIST_STATUS = ['LRE', 'LRN', 'LRR']
+GEO_STATUS = ['France', 'France métropolitaine']
 
 ###########################
 ###########################

--- a/atlas/configuration/config.py.sample
+++ b/atlas/configuration/config.py.sample
@@ -102,8 +102,8 @@ MAP = {
 ###########################
 ###########################
 
-LIST_STATUS = ['LRE', 'LRN', 'LRNh', 'LRNm', 'LRNn', 'LRNp', 'LRR', 'LRRm', 'LRRn']
-GEO_STATUS = ['France', 'France métropolitaine', 'Bretagne', 'Côtes-d''Armor', 'Finistère', 'Morbihan', 'Ille-et-Vilaine']
+LIST_STATUS = ['LRE', 'LRN', 'LRR']
+GEO_STATUS = ['France', 'France métropolitaine']
 
 ###########################
 ###########################

--- a/atlas/configuration/config.py.sample
+++ b/atlas/configuration/config.py.sample
@@ -98,6 +98,15 @@ MAP = {
 
 ###########################
 ###########################
+######### STATUTS #########
+###########################
+###########################
+
+LIST_STATUS = ['LRE', 'LRN', 'LRNh', 'LRNm', 'LRNn', 'LRNp', 'LRR', 'LRRm', 'LRRn']
+GEO_STATUS = ['France', 'France métropolitaine', 'Bretagne', 'Côtes-d''Armor', 'Finistère', 'Morbihan', 'Ille-et-Vilaine']
+
+###########################
+###########################
 #### Security  Config #####
 ###########################
 ###########################

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -204,6 +204,7 @@ class AtlasConfig(Schema):
     SPLIT_NOM_VERN = fields.Boolean(load_default=True)
     INTERACTIVE_MAP_LIST = fields.Boolean(load_default=True)
     AVAILABLE_LANGUAGES = fields.Dict(load_default=LANGUAGES)
+    STATUS_BDC_ENABLE = fields.Boolean(load_default=True)
     # Flask parameter enabling auto reload of templates
     # (no need to restart the atlas service when updating templates)
     # Defaults to False to have the best performance in production

--- a/atlas/modeles/entities/vmStatutBdc.py
+++ b/atlas/modeles/entities/vmStatutBdc.py
@@ -1,0 +1,20 @@
+# -*- coding:utf-8 -*-
+
+from sqlalchemy import Column, Integer, MetaData, String, Table, Float
+from sqlalchemy.ext.declarative import declarative_base
+
+from atlas.utils import engine
+
+Base = declarative_base()
+metadata = MetaData()
+
+class VmStatutBdc(Base):
+    __table__ = Table(
+        'vm_taxons', metadata,
+        Column('cd_ref', Integer),
+        Column('code_statut', String(50)),
+        Column('label_statut', String(250)),
+        Column('cd_type_statut', String(50)),
+        Column('lb_type_statut', String(250)),
+        schema='atlas', autoload=True, autoload_with=engine
+    )

--- a/atlas/modeles/repositories/vmStatutBdcRepository.py
+++ b/atlas/modeles/repositories/vmStatutBdcRepository.py
@@ -1,0 +1,24 @@
+from flask import current_app
+from sqlalchemy.sql import text
+
+from atlas.modeles import utils
+
+def fctSortDict(value):
+    return value['cd_type_statut']
+
+def getTaxonsStatutBdc(connection, cd_ref):
+    sql="SELECT * FROM atlas.vm_statut_bdc WHERE cd_ref = :thiscdref"
+    req = connection.execute(text(sql), thiscdref=cd_ref)
+    tsb = list()
+    for r in req:
+        temp = {
+            'code_statut':r.code_statut,
+            'label_statut':r.label_statut,
+            'cd_type_statut':r.cd_type_statut,
+            'lb_type_statut':r.lb_type_statut,
+            'lb_adm_tr':r.lb_adm_tr
+        }
+        tsb.append(temp)
+    taxonStatutBdc = sorted(tsb, key=fctSortDict)
+    
+    return taxonStatutBdc

--- a/atlas/static/css/ficheEspece.css
+++ b/atlas/static/css/ficheEspece.css
@@ -284,3 +284,78 @@ text {
 .carousel-indicators {
   bottom: 0px;
 }
+
+#statut-bdc {
+  margin-top: 15px;
+  padding-top : 10px;
+  padding-bottom : 10px;
+}
+
+div#statut-bdc span.NT {
+  color: white;
+	background-color: #cce226 ;
+} 
+
+div#statut-bdc span.LC {
+  color: white;
+	background-color: #60c659 ;
+}
+
+div#statut-bdc span.EN {
+  color: white;
+	background-color: #fc7f3f ;
+}
+
+div#statut-bdc span.VU {
+	background-color: #f9e814 ;
+}
+
+div#statut-bdc span.CR {
+  color: white;
+	background-color: #d81e05 ;
+}
+
+div#statut-bdc span.RE {
+	color: white;
+	background-color: #5b1064 ;
+}
+
+div#statut-bdc span.NA {
+	color: white;
+	background-color: #929392 ;
+}
+
+div#statut-bdc span.NE {
+	background-color: white ;
+}
+
+div#statut-bdc span.DD {
+	background-color: #d1d1c6 ;
+}
+
+div#statut-bdc span.DHFF {
+  color: white;
+	background-color: #afdde9 ;
+}
+
+div#statut-bdc span.PN {
+  color: white;
+	background-color: #ffccaa ;
+}
+
+div#statut-bdc span.bloc-statut-bdc {
+  /*border: 1px solid grey;
+  padding: 5px;*/
+  padding-left: 5px;
+  padding-right: 5px;
+  border-radius: 25%;
+
+}
+
+div#statut-bdc span {
+	border-radius: 10%;
+}
+
+div#statut-bdc span.bloc-sbdc-new {
+  margin-left: 15px;
+} 

--- a/atlas/templates/speciesSheet/identityCard.html
+++ b/atlas/templates/speciesSheet/identityCard.html
@@ -91,6 +91,43 @@
                     {% endfor %}
                 </div>
 
+                {% if configuration.STATUS_BDC_ENABLE %}
+                    <div id ="statut-bdc">
+                        {% for sbdc in statutBdc %}
+                            {% if loop.first %}
+                                {{sbdc.cd_type_statut}} :
+                                <span 
+                                    data-toggle='tooltip' 
+                                    data-placement='right' 
+                                    data-original-title="{{sbdc.lb_type_statut}} {% if sbdc.cd_type_statut != 'LRE' %}({{sbdc.lb_adm_tr}}) {% endif %}: {{sbdc.label_statut}}"
+                                    > 
+                                    <span class="{{sbdc.code_statut}} bloc-statut-bdc">{{sbdc.code_statut}}</span>
+                                </span>
+                            {% else %}
+                                {% set prev_key = loop.index0 - 1 %}
+                                {% if sbdc.cd_type_statut == statutBdc[prev_key].cd_type_statut %}
+                                    <span 
+                                        data-toggle='tooltip' 
+                                        data-placement='right' 
+                                        data-original-title="{{sbdc.lb_type_statut}} {% if sbdc.cd_type_statut != 'LRE' %}({{sbdc.lb_adm_tr}}) {% endif %} : {{sbdc.label_statut}}"
+                                        >
+                                        <span class="{{sbdc.code_statut}} bloc-statut-bdc">{{sbdc.code_statut}}</span>
+                                    </span>
+                                {% else %}
+                                    <span class="bloc-sbdc-new">{{sbdc.cd_type_statut}} :</span> 
+                                    <span
+                                        data-toggle='tooltip' 
+                                        data-placement='right' 
+                                        data-original-title="{{sbdc.lb_type_statut}} {% if sbdc.cd_type_statut != 'LRE' %}({{sbdc.lb_adm_tr}}) {% endif %} : {{sbdc.label_statut}}"
+                                        >
+                                        <span class="{{sbdc.code_statut}} bloc-statut-bdc">{{sbdc.code_statut}}</span>
+                                    </span>
+                                {% endif %}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+
                 <div id="inpnLink">
                     <a href='https://inpn.mnhn.fr/espece/cd_nom/{{ taxon.taxonSearch.cd_ref }}' target="_blank">
                         <img width="90px" src="{{ url_for('static', filename='images/logo_inpn.png') }}"

--- a/data/atlas/15.atlas.vm_statut_bdc
+++ b/data/atlas/15.atlas.vm_statut_bdc
@@ -107,8 +107,4 @@ AS
   GROUP BY bs.cd_ref, bs.code_statut, bs.label_statut, bs.cd_type_statut, bs.lb_type_statut, bs.lb_adm_tr
 WITH DATA;
 
-ALTER TABLE IF EXISTS atlas.vm_statut_bdc
-    OWNER TO geonatadmin;
-
-GRANT ALL ON TABLE atlas.vm_statut_bdc TO geonatadmin;
-GRANT SELECT ON TABLE atlas.vm_statut_bdc TO geonatatlas;
+GRANT SELECT ON TABLE atlas.vm_statut_bdc TO my_reader_user;

--- a/data/atlas/15.atlas.vm_statut_bdc
+++ b/data/atlas/15.atlas.vm_statut_bdc
@@ -1,0 +1,114 @@
+CREATE FOREIGN TABLE taxonomie.bdc_statut (
+    id int4 OPTIONS(column_name 'id') NOT NULL,
+    cd_nom int4 OPTIONS(column_name 'cd_nom') NOT NULL,
+    cd_ref int4 OPTIONS(column_name 'cd_ref') NOT NULL,
+    cd_sup int4 OPTIONS(column_name 'cd_sup') NULL,
+    cd_type_statut varchar(50) OPTIONS(column_name 'cd_type_statut') NOT NULL,
+    lb_type_statut varchar(250) OPTIONS(column_name 'lb_type_statut') NULL,
+    regroupement_type varchar(250) OPTIONS(column_name 'regroupement_type') NULL,
+    code_statut varchar(250) OPTIONS(column_name 'code_statut') NULL,
+    label_statut varchar(1000) OPTIONS(column_name 'label_statut') NULL,
+    rq_statut text OPTIONS(column_name 'rq_statut') NULL,
+    cd_sig varchar(100) OPTIONS(column_name 'cd_sig') NULL,
+    cd_doc int4 OPTIONS(column_name 'cd_doc') NULL,
+    lb_nom varchar(1000) OPTIONS(column_name 'lb_nom') NULL,
+    lb_auteur varchar(1000) OPTIONS(column_name 'lb_auteur') NULL,
+    nom_complet_html varchar(1000) OPTIONS(column_name 'nom_complet_html') NULL,
+    nom_valide_html varchar(1000) OPTIONS(column_name 'nom_valide_html') NULL,
+    regne varchar(250) OPTIONS(column_name 'regne') NULL,
+    phylum varchar(250) OPTIONS(column_name 'phylum') NULL,
+    classe varchar(250) OPTIONS(column_name 'classe') NULL,
+    ordre varchar(250) OPTIONS(column_name 'ordre') NULL,
+    famille varchar(250) OPTIONS(column_name 'famille') NULL,
+    group1_inpn varchar(255) OPTIONS(column_name 'group1_inpn') NULL,
+    group2_inpn varchar(255) OPTIONS(column_name 'group2_inpn') NULL,
+    lb_adm_tr varchar(100) OPTIONS(column_name 'lb_adm_tr') NULL,
+    niveau_admin varchar(250) OPTIONS(column_name 'niveau_admin') NULL,
+    cd_iso3166_1 varchar(50) OPTIONS(column_name 'cd_iso3166_1') NULL,
+    cd_iso3166_2 varchar(50) OPTIONS(column_name 'cd_iso3166_2') NULL,
+    full_citation text OPTIONS(column_name 'full_citation') NULL,
+    doc_url text OPTIONS(column_name 'doc_url') NULL,
+    thematique varchar(100) OPTIONS(column_name 'thematique') NULL,
+    type_value varchar(100) OPTIONS(column_name 'type_value') NULL
+)
+SERVER geonaturedbserver
+OPTIONS (schema_name 'taxonomie', table_name 'bdc_statut');
+
+
+CREATE FOREIGN TABLE taxonomie.bdc_statut_cor_text_values (
+	id_value_text serial4 OPTIONS(column_name 'id_value_text') NOT NULL,
+	id_value int4 OPTIONS(column_name 'id_value') NOT NULL,
+	id_text int4 OPTIONS(column_name 'id_text') NOT NULL
+)
+SERVER geonaturedbserver
+OPTIONS (schema_name 'taxonomie', table_name 'bdc_statut_cor_text_values');
+
+
+CREATE FOREIGN TABLE taxonomie.bdc_statut_taxons (
+	id int4 OPTIONS(column_name 'id') NOT NULL,
+	id_value_text int4 OPTIONS(column_name 'id_value_text') NOT NULL,
+	cd_nom int4 OPTIONS(column_name 'cd_nom') NOT NULL,
+	cd_ref int4 OPTIONS(column_name 'cd_ref') NOT NULL,
+	rq_statut varchar(1000) OPTIONS(column_name 'rq_statut') NULL
+)
+SERVER geonaturedbserver
+OPTIONS (schema_name 'taxonomie', table_name 'bdc_statut_taxons');
+
+
+CREATE FOREIGN TABLE taxonomie.bdc_statut_text (
+	id_text serial4 OPTIONS(column_name 'id_text') NOT NULL,
+	cd_st_text varchar(50) OPTIONS(column_name 'cd_st_text') NULL,
+	cd_type_statut varchar(50) OPTIONS(column_name 'cd_type_statut') NOT NULL,
+	cd_sig varchar(50) OPTIONS(column_name 'cd_sig') NULL,
+	cd_doc int4 OPTIONS(column_name 'cd_doc') NULL,
+	niveau_admin varchar(250) OPTIONS(column_name 'niveau_admin') NULL,
+	cd_iso3166_1 varchar(50) OPTIONS(column_name 'cd_iso3166_1') NULL,
+	cd_iso3166_2 varchar(50) OPTIONS(column_name 'cd_iso3166_2') NULL,
+	lb_adm_tr varchar(250) OPTIONS(column_name 'lb_adm_tr') NULL,
+	full_citation text OPTIONS(column_name 'full_citation') NULL,
+	doc_url text OPTIONS(column_name 'doc_url') NULL,
+	"enable" bool OPTIONS(column_name 'enable') NULL DEFAULT true
+)
+SERVER geonaturedbserver
+OPTIONS (schema_name 'taxonomie', table_name 'bdc_statut_text');
+
+
+CREATE FOREIGN TABLE taxonomie.bdc_statut_type (
+	cd_type_statut varchar(50) OPTIONS(column_name 'cd_type_statut') NOT NULL,
+	lb_type_statut varchar(250) OPTIONS(column_name 'lb_type_statut') NULL,
+	regroupement_type varchar(250) OPTIONS(column_name 'regroupement_type') NULL,
+	thematique varchar(100) OPTIONS(column_name 'thematique') NULL,
+	type_value varchar(100) OPTIONS(column_name 'type_value') NULL
+)
+SERVER geonaturedbserver
+OPTIONS (schema_name 'taxonomie', table_name 'bdc_statut_type');
+
+
+CREATE FOREIGN TABLE taxonomie.bdc_statut_values (
+	id_value serial4 OPTIONS(column_name 'id_value') NOT NULL,
+	code_statut varchar(50) OPTIONS(column_name 'code_statut') NOT NULL,
+	label_statut varchar(250) OPTIONS(column_name 'label_statut') NULL
+)
+SERVER geonaturedbserver
+OPTIONS (schema_name 'taxonomie', table_name 'bdc_statut_values');
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS atlas.vm_statut_bdc
+TABLESPACE pg_default
+AS
+ SELECT bs.cd_ref,
+    bs.code_statut,
+    bs.label_statut,
+    bs.cd_type_statut,
+    bs.lb_type_statut,
+    bs.lb_adm_tr
+   FROM taxonomie.bdc_statut bs
+     JOIN taxonomie.bdc_statut_text bstext ON bstext.cd_type_statut::text = bs.cd_type_statut::text AND bstext.full_citation = bs.full_citation
+  WHERE (bs.cd_type_statut::text = ANY (ARRAY['LRE'::character varying::text, 'LRN'::character varying::text, 'LRNh'::character varying::text, 'LRNm'::character varying::text, 'LRNn'::character varying::text, 'LRNp'::character varying::text, 'LRR'::character varying::text, 'LRRm'::character varying::text, 'LRRn'::character varying::text])) AND (bs.lb_adm_tr::text = ANY (ARRAY['France'::character varying::text, 'France métropolitaine'::character varying::text, 'Bretagne'::character varying::text, 'Côtes-d''Armor'::character varying::text, 'Finistère'::character varying::text, 'Morbihan'::character varying::text, 'Ille-et-Vilaine'::character varying::text])) AND bstext.enable = true
+  GROUP BY bs.cd_ref, bs.code_statut, bs.label_statut, bs.cd_type_statut, bs.lb_type_statut, bs.lb_adm_tr
+WITH DATA;
+
+ALTER TABLE IF EXISTS atlas.vm_statut_bdc
+    OWNER TO geonatadmin;
+
+GRANT ALL ON TABLE atlas.vm_statut_bdc TO geonatadmin;
+GRANT SELECT ON TABLE atlas.vm_statut_bdc TO geonatatlas;

--- a/data/atlas/15.atlas.vm_statut_bdc
+++ b/data/atlas/15.atlas.vm_statut_bdc
@@ -103,7 +103,7 @@ AS
     bs.lb_adm_tr
    FROM taxonomie.bdc_statut bs
      JOIN taxonomie.bdc_statut_text bstext ON bstext.cd_type_statut::text = bs.cd_type_statut::text AND bstext.full_citation = bs.full_citation
-  WHERE (bs.cd_type_statut::text = ANY (ARRAY['LRE'::character varying::text, 'LRN'::character varying::text, 'LRNh'::character varying::text, 'LRNm'::character varying::text, 'LRNn'::character varying::text, 'LRNp'::character varying::text, 'LRR'::character varying::text, 'LRRm'::character varying::text, 'LRRn'::character varying::text])) AND (bs.lb_adm_tr::text = ANY (ARRAY['France'::character varying::text, 'France métropolitaine'::character varying::text, 'Bretagne'::character varying::text, 'Côtes-d''Armor'::character varying::text, 'Finistère'::character varying::text, 'Morbihan'::character varying::text, 'Ille-et-Vilaine'::character varying::text])) AND bstext.enable = true
+  WHERE (bs.cd_type_statut = ANY (ARRAY['LRE', 'LRN', 'LRR'])) AND (bs.lb_adm_tr = ANY (ARRAY['France', 'France métropolitaine'])) AND bstext.enable = true
   GROUP BY bs.cd_ref, bs.code_statut, bs.label_statut, bs.cd_type_statut, bs.lb_type_statut, bs.lb_adm_tr
 WITH DATA;
 

--- a/install_db.sh
+++ b/install_db.sh
@@ -405,6 +405,11 @@ if ! database_exists $db_name
         export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/11.atlas.vm_cor_taxon_organism.sql  &>> log/install_db.log
         echo "[$(date +'%H:%M:%S')] Passed - Duration : $((($SECONDS-$time_temp)/60))m$((($SECONDS-$time_temp)%60))s"
 
+        echo "[$(date +'%H:%M:%S')] Creating atlas.atlas.vm_statut_bdc..."
+        time_temp=$SECONDS
+        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/15.atlas.vm_statut_bdc.sql  &>> log/install_db.log
+        echo "[$(date +'%H:%M:%S')] Passed - Duration : $((($SECONDS-$time_temp)/60))m$((($SECONDS-$time_temp)%60))s"
+        
         echo "[$(date +'%H:%M:%S')] Creating function refresh vm..."
         time_temp=$SECONDS
         export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/atlas.refresh_materialized_view_data.sql  &>> log/install_db.log

--- a/install_db.sh
+++ b/install_db.sh
@@ -409,6 +409,7 @@ if ! database_exists $db_name
         then
             echo "[$(date +'%H:%M:%S')] Creating atlas.atlas.vm_statut_bdc..."
             time_temp=$SECONDS
+            sudo sed -i "s/WHERE (bs.cd_type_statut = ANY (ARRAY['LRE', 'LRN', 'LRR'])) AND (bs.lb_adm_tr = ANY (ARRAY['France', 'France métropolitaine'])) AND bstext.enable = true$/WHERE (bs.cd_type_statut = ANY (ARRAY$list_status)) AND (bs.lb_adm_tr = ANY (ARRAY$geo_status)) AND bstext.enable = true/"
             export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/15.atlas.vm_statut_bdc.sql  &>> log/install_db.log
             echo "[$(date +'%H:%M:%S')] Passed - Duration : $((($SECONDS-$time_temp)/60))m$((($SECONDS-$time_temp)%60))s"
         fi

--- a/install_db.sh
+++ b/install_db.sh
@@ -405,10 +405,13 @@ if ! database_exists $db_name
         export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/11.atlas.vm_cor_taxon_organism.sql  &>> log/install_db.log
         echo "[$(date +'%H:%M:%S')] Passed - Duration : $((($SECONDS-$time_temp)/60))m$((($SECONDS-$time_temp)%60))s"
 
-        echo "[$(date +'%H:%M:%S')] Creating atlas.atlas.vm_statut_bdc..."
-        time_temp=$SECONDS
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/15.atlas.vm_statut_bdc.sql  &>> log/install_db.log
-        echo "[$(date +'%H:%M:%S')] Passed - Duration : $((($SECONDS-$time_temp)/60))m$((($SECONDS-$time_temp)%60))s"
+        if $use_ref_geo_gn2
+        then
+            echo "[$(date +'%H:%M:%S')] Creating atlas.atlas.vm_statut_bdc..."
+            time_temp=$SECONDS
+            export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas/15.atlas.vm_statut_bdc.sql  &>> log/install_db.log
+            echo "[$(date +'%H:%M:%S')] Passed - Duration : $((($SECONDS-$time_temp)/60))m$((($SECONDS-$time_temp)%60))s"
+        fi
         
         echo "[$(date +'%H:%M:%S')] Creating function refresh vm..."
         time_temp=$SECONDS


### PR DESCRIPTION
Ajout des statuts de protection des espèces aux fiches espèces :

![image](https://github.com/PnX-SI/GeoNature-atlas/assets/22146605/7c544d99-9b50-448e-b6b6-8c9b743e3ca4)

L'affichage des statuts se base sur la BDC présente dans la base geonature2db (via foreign data wrapping et materialized view)