### PR TITLE
fix: allow negative cd_ref

### DIFF
--- a/atlas/atlasAPI.py
+++ b/atlas/atlasAPI.py
@@ -37,7 +37,7 @@ def searchCommuneAPI():
 
 if not current_app.config["AFFICHAGE_MAILLE"]:
 
-    @api.route("/observationsMailleAndPoint/<int:cd_ref>", methods=["GET"])
+    @api.route("/observationsMailleAndPoint/<int(signed=True):cd_ref>", methods=["GET"])
     def getObservationsMailleAndPointAPI(cd_ref):
         """
         Retourne les observations d'un taxon en point et en maille
@@ -55,7 +55,7 @@ if not current_app.config["AFFICHAGE_MAILLE"]:
         return jsonify(observations)
 
 
-@api.route("/observationsMaille/<int:cd_ref>", methods=["GET"])
+@api.route("/observationsMaille/<int(signed=True):cd_ref>", methods=["GET"])
 def getObservationsMailleAPI(cd_ref):
     """
     Retourne les observations d'un taxon par maille (et le nombre d'observation par maille)
@@ -75,7 +75,7 @@ def getObservationsMailleAPI(cd_ref):
 
 if not current_app.config["AFFICHAGE_MAILLE"]:
 
-    @api.route("/observationsPoint/<int:cd_ref>", methods=["GET"])
+    @api.route("/observationsPoint/<int(signed=True):cd_ref>", methods=["GET"])
     def getObservationsPointAPI(cd_ref):
         session = db.session
         observations = vmObservationsRepository.searchObservationsChilds(session, cd_ref)
@@ -83,7 +83,7 @@ if not current_app.config["AFFICHAGE_MAILLE"]:
         return jsonify(observations)
 
 
-@api.route("/observations/<int:cd_ref>", methods=["GET"])
+@api.route("/observations/<int(signed=True):cd_ref>", methods=["GET"])
 def getObservationsGenericApi(cd_ref: int):
     """[summary]
 
@@ -110,7 +110,7 @@ def getObservationsGenericApi(cd_ref: int):
 
 if not current_app.config["AFFICHAGE_MAILLE"]:
 
-    @api.route("/observations/<insee>/<int:cd_ref>", methods=["GET"])
+    @api.route("/observations/<insee>/<int(signed=True):cd_ref>", methods=["GET"])
     def getObservationsCommuneTaxonAPI(insee, cd_ref):
         connection = db.engine.connect()
         observations = vmObservationsRepository.getObservationTaxonCommune(
@@ -120,7 +120,7 @@ if not current_app.config["AFFICHAGE_MAILLE"]:
         return jsonify(observations)
 
 
-@api.route("/observationsMaille/<insee>/<int:cd_ref>", methods=["GET"])
+@api.route("/observationsMaille/<insee>/<int(signed=True):cd_ref>", methods=["GET"])
 def getObservationsCommuneTaxonMailleAPI(insee, cd_ref):
     connection = db.engine.connect()
     observations = vmObservationsMaillesRepository.getObservationsTaxonCommuneMaille(


### PR DESCRIPTION
Salut,

Je fais suite à la PR de TaxHhub qui permettait d'accepter des cd_nom/cd_ref négatif : https://github.com/PnX-SI/TaxHub/pull/368

@TheoLechemia  et @camillemonchicourt  vous mentionnez le fait qu'il fallait répercuter ce fix sur l'atlas. Sauf erreur de ma part, je n'ai pas trouvé de PR associée.

Du coup je fais celle ci !

Merci d'avance pour votre lecture :) 