### PR TITLE
Fix standalone install and add debian 12 support

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -1,0 +1,17 @@
+name: Check pip install package with multiple version of python
+on: [push, pull_request]
+
+jobs:
+  check-requirements-install:
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.12" ]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: pip install -r requirements.txt

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,10 +5,15 @@ CHANGELOG
 [Unreleased]
 ------------------
 
+🚀 **Nouveautés**
+
+- Mise à jour de la dependance `greenlet` afin de pouvoir installer l'atlas sur une version de debian 12 (@juggler31)
+
 🐛 **Corrections**
 
 - Correction de la carte avec affichage par mailles de la fiche "Commune" (#533 par @jpm-cbna)
 - Correction et amélioration de l'affichage de la fenêtre listant les sous-taxons aggrégés (#558 par @jpm-cbna)
+- Correction du script install_db.sh afin d'installer l'atlas sans geonature. (@juggler31)
 
 🐛 **Optimisations**
 

--- a/install_db.sh
+++ b/install_db.sh
@@ -132,6 +132,10 @@ if ! database_exists $db_name
                     -v type_territoire=$type_territoire \
                     -f data/gn2/atlas_ref_geo.sql &>> log/install_db.log
         else
+
+            echo "Create extension defined in geonature"
+            sudo -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS unaccent;"  &>> log/install_db.log
+
             # FR: Import du shape des limites du territoire ($limit_shp) dans la BDD / atlas.t_layer_territoire
             # EN: Import of the shape of the territory limits ($limit_shp) in the BDD / atlas.t_layer_territory
 
@@ -325,6 +329,9 @@ if ! database_exists $db_name
             echo "Creating syntheseff example table"
             sudo -n -u postgres -s psql -d $db_name -f /tmp/atlas/without_geonature.sql &>> log/install_db.log
             sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE synthese.syntheseff OWNER TO "$owner_atlas";"
+
+            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE utilisateurs.bib_organismes OWNER TO "$owner_atlas";"
+            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE gn_meta.cor_dataset_actor OWNER TO "$owner_atlas";"
         fi
 
         # FR: Creation des Vues Matérialisées (et remplacement éventuel des valeurs en dur par les paramètres)

--- a/install_env.sh
+++ b/install_env.sh
@@ -24,6 +24,7 @@ sudo apt-get -y upgrade
 # Go to folder of install_env.sh
 cd "$(dirname "$0")"
 
+sudo apt-get install -y wget
 sudo apt-get install -y unzip
 sudo apt-get install -y apache2
 sudo a2enmod proxy
@@ -51,11 +52,11 @@ then
 fi
 
 
-sudo apt-get install -y python-setuptools
+sudo apt-get install -y python3-setuptools
 sudo apt-get install -y libpq-dev python3-dev
 
-sudo apt-get install python-pip
-sudo apt-get install -y python-gdal
+sudo apt-get install python3-pip
+sudo apt-get install -y python3-gdal
 sudo apt-get install -y gdal-bin
 
 sudo apt-get install -y python3-virtualenv virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ geoalchemy2==0.9.4
     # via -r requirements.in
 geojson==2.5.0
     # via -r requirements.in
-greenlet==1.1.3
+greenlet==3.0.3
     # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in


### PR DESCRIPTION
Cette PR corrige les installations sur un debian 12.

- Update de la library greenlet
- Correction de l'installation de l'atlas de manière autonome.
- Ajout d'un test d'installation des paquets python dans les github actions  