### PR TITLE
Allow docker images build and publication to forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,13 +31,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/geonature-atlas
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - allow_docker_images_fork
   release:
     types: [published]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,27 +4,38 @@ on:
   push:
     branches:
       - develop
+      - allow_docker_images_fork
   release:
     types: [published]
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write  # required to publish docker image
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: ${{ ! (github.event_name == 'release' && github.event.action == 'published') }}
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Docker meta
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/pnx-si/geonature-atlas
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/geonature-atlas
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
@@ -32,8 +43,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Build and export
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           target: prod


### PR DESCRIPTION
J'utilise les variables d'env de github actions pour définir le nom de l'image docker.
Ça a pour effet de permettre aux forks de publier leur propres images docker sur leur dépot github, plutôt que de pousser sur le dépot ecrit en dur dans le fichier.
ça ne change rien pour le dépot original qui aura toujours son image docker disponible sous `ghcr.io/pnx-si/geonature-atlas`