### PR TITLE
fix: picture lazy loading on home page

### DIFF
--- a/atlas/templates/core/listTaxons.html
+++ b/atlas/templates/core/listTaxons.html
@@ -29,7 +29,7 @@
                              src="{{ url_for('static', filename='images/picto_'+ taxon.group2_inpn| replace(" ", "_") |urlencode+'.png') }}" alt=" " />
                     {% else %}
                         {% if configuration.REDIMENSIONNEMENT_IMAGE %}
-                            {% set img_path = configuration.TAXHUB_URL+'/api/tmedias/thumbnail/'+taxon.id_media|string+'?h=500&w=500' %}
+                            {% set img_path = configuration.TAXHUB_URL+'/api/tmedias/thumbnail/'+taxon.id_media|string+'?h=80&w=80' %}
                         {% else %}
                             {% set img_path = taxon.path %}
                         {% endif %}

--- a/atlas/templates/core/listTaxons.html
+++ b/atlas/templates/core/listTaxons.html
@@ -25,16 +25,15 @@
                 <div class="pictoImgList mr-2" data-toggle="tooltip" data-original-title="{{ taxon.group2_inpn }}"
                      data-placement="right">
                     {% if taxon.path == None %}
-                        <img class="mx-auto d-block INPNgroup"
-                             src="{{ url_for('static', filename='images/picto_'+ taxon.group2_inpn| replace(" ", "_") |urlencode+'.png') }}">
-
+                        <img loading="lazy" class="mx-auto d-block INPNgroup"
+                             src="{{ url_for('static', filename='images/picto_'+ taxon.group2_inpn| replace(" ", "_") |urlencode+'.png') }}" alt=" " />
                     {% else %}
                         {% if configuration.REDIMENSIONNEMENT_IMAGE %}
                             {% set img_path = configuration.TAXHUB_URL+'/api/tmedias/thumbnail/'+taxon.id_media|string+'?h=500&w=500' %}
                         {% else %}
                             {% set img_path = taxon.path %}
                         {% endif %}
-                        <img class="lazy pictoImgList" data-src="{{ img_path }}">
+                        <img loading="lazy" class="pictoImgList" src="{{ img_path }}" alt=" " />
                     {% endif %}
                 </div>
                 <div class="media-body">

--- a/atlas/templates/core/listTaxons.html
+++ b/atlas/templates/core/listTaxons.html
@@ -11,7 +11,7 @@
     <div class="bg-white border-right p-2">
 
         <div class="col">
-            <input id="taxonInput" type="text" class="form-control  form-control-sm" placeholder="{{ _('filter.species') }}">
+            <input id="taxonInput" type="text" class="form-control  form-control-sm" placeholder="{{ _('filter.species') }}" />
         </div>
 
     </div>
@@ -45,7 +45,7 @@
                                                                target="_blank">
                                     <img src="{{ url_for('static', filename='images/logo_protection.png') }}"
                                          style="width : 30px; height: 30px" data-placement="left" data-toggle="tooltip"
-                                         data-original-title="{{ _('this.taxon.has.a.protected.status') }}">
+                                         data-original-title="{{ _('this.taxon.has.a.protected.status') }}" alt=" " />
                                                 </a>
                                                    {% endif %}
                                                {% endif %}
@@ -57,7 +57,7 @@
                                 style="width : 30px; height: 30px" data-placement="left" data-toggle="tooltip"
                                 data-original-title="{{ configuration.PATRIMONIALITE.config[taxon.patrimonial].text }}"
                                 data-placement="right"
-                        >
+                        alt=" " />
                     {% endif %}
                 {% endif %}
 
@@ -83,7 +83,7 @@
                     <a class="badge badge-primary" href="{{ url_for('main.ficheEspece', cd_nom=taxon.cd_ref) }}"
                        data-toggle="tooltip"
                        title="{{ _('check.species.sheet') }}" data-placement="left">
-                        <i class="fas fa-list fa-fw"></i> {{ _('species.sheet') }}</i>
+                        <i class="fas fa-list fa-fw"></i> {{ _('species.sheet') }}
                     </a>
                     </span>
 


### PR DESCRIPTION
Le "lazy loading" des images des taxons sur la page d'accueil ne marche pas - au pire - ou mal - au mieux. IL es tfait en JS avec jquery et ne semble plus fonctionner comme il faut.

- J'ai remplacé le comportement par du lazy loading HTML5 car maintenant tous les navigateurs le supportent
- J'ai fixé la taille des miniatures en 80x80 car la classe CSS limit déjà l'image à cette taille
- J'ai corrigé quelques erreurs de structure et sémantique html (`alt=" "` pour eviter le logo de l'image cassée, balises en double ou mal fermées)