### PR TITLE
Feat/ajout liens importants taxons

### DIFF
--- a/atlas/atlasRoutes.py
+++ b/atlas/atlasRoutes.py
@@ -273,6 +273,18 @@ def ficheEspece(cd_nom):
     articles = vmMedias.getLinks_and_articles(
         connection, cd_ref, current_app.config["ATTR_LIEN"], current_app.config["ATTR_PDF"]
     )
+
+    liens_importants = []
+    if current_app.config.get("TYPES_MEDIAS_LIENS_IMPORTANTS"):
+        liens_config = current_app.config["TYPES_MEDIAS_LIENS_IMPORTANTS"]
+        media_type_ids = list({t["type_media_id"] for t in liens_config})
+        liens_importants = vmMedias.get_liens_importants(connection, cd_ref, media_type_ids)
+        icones_by_media_type = {
+            i["type_media_id"]: i["icon"] for i in liens_config if i.get("icon")
+        }
+        for lien in liens_importants:
+            lien["icon"] = icones_by_media_type.get(lien["id_type"], "")
+
     taxonDescription = vmCorTaxonAttribut.getAttributesTaxon(
         connection,
         cd_ref,
@@ -303,6 +315,7 @@ def ficheEspece(cd_nom):
         photoCarousel=photoCarousel,
         videoAudio=videoAudio,
         articles=articles,
+        liensImportants=liens_importants,
         taxonDescription=taxonDescription,
         observers=observers,
         organisms=organisms,

--- a/atlas/configuration/config.py.example
+++ b/atlas/configuration/config.py.example
@@ -283,6 +283,26 @@ ATTR_VIMEO = 9
 # Coupe le nom_vernaculaire à la 1ere virgule sur les fiches espèces
 SPLIT_NOM_VERN = True
 
+# Permet de définir des types de médias TaxHub comme « Liens importants » de la fiche taxon.
+# Les liens importants sont mis en avant dans l'affichage de la fiche.
+# - `type_media_id` : l'ID d'un type de média définit dans l'instance TaxHub.
+# - `icon` (optionnel) : l'URL d'une image à ajouter sur le bouton du lien.
+#
+# Exemple de configuration :
+# (les types médias et les icones sont des exemples et n'existent pas de base
+# sur une instance Atlas/TaxHub)
+TYPES_MEDIAS_LIENS_IMPORTANTS = [
+  {
+    'type_media_id': 10,  # Lien participation campagne d'observation
+    'icon': '/static/custom/images/jumelles.svg'
+  },
+  {
+    'type_media_id': 11,  # Lien vers fiche focus territoire
+    'icon': '/static/custom/images/logo_fiche_focus.png'
+  }
+]
+
+
 ############################################
 #### FICHE "AREA" ET RANG TAXONOMIQUE  #####
 ############################################

--- a/atlas/configuration/config.py.example
+++ b/atlas/configuration/config.py.example
@@ -288,6 +288,9 @@ SPLIT_NOM_VERN = True
 # - `type_media_id` : l'ID d'un type de média définit dans l'instance TaxHub.
 # - `icon` (optionnel) : l'URL d'une image à ajouter sur le bouton du lien.
 #
+# Une classe CSS `lien-important-type-XX` est ajoutée sur l'élément HTML du lien avec XX l'ID du type
+# de média. Cela permet de personnaliser l'apparence des liens, par type, dans `custom.css`.
+#
 # Exemple de configuration :
 # (les types médias et les icones sont des exemples et n'existent pas de base
 # sur une instance Atlas/TaxHub)

--- a/atlas/modeles/repositories/vmMedias.py
+++ b/atlas/modeles/repositories/vmMedias.py
@@ -160,6 +160,17 @@ def getLinks_and_articles(connection, cd_ref, id3, id4):
     return [_format_media(r) for r in req]
 
 
+def get_liens_importants(connection, cd_ref, media_ids):
+    sql = """
+        SELECT *
+        FROM atlas.vm_medias
+        WHERE id_type = ANY(:media_ids) AND cd_ref = :thiscdref
+        ORDER BY date_media DESC
+    """
+    req = connection.execute(text(sql), thiscdref=cd_ref, media_ids=media_ids)
+    return [_format_media(r) for r in req]
+
+
 def getPhotosGallery(connection, id1, id2):
     sql = """
         SELECT m.*, t.nom_vern, t.lb_nom, t.nb_obs

--- a/atlas/static/css/ficheEspece.css
+++ b/atlas/static/css/ficheEspece.css
@@ -138,6 +138,32 @@ p.imgDescription.main {
     padding: 0px;
 }
 
+/* Liens importants */
+
+.liens-importants-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem 0;
+}
+
+.lien-important {
+  display: flex;
+  background-color: var(--main-color);
+  color: white;
+  text-decoration: none;
+  border-radius: 10px;
+  padding: 0.5rem 1rem;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.lien-important:hover {
+  background-color: var(--second-color);
+  color: white;
+  text-decoration: none;
+}
+
 /*Medias*/
 
 i.btn-more {

--- a/atlas/static/css/ficheEspece.css
+++ b/atlas/static/css/ficheEspece.css
@@ -142,9 +142,11 @@ p.imgDescription.main {
 
 .liens-importants-container {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0.7rem 0;
+  justify-content: center;
+  gap: 0.7rem 0.7rem;
 }
 
 .lien-important {

--- a/atlas/templates/speciesSheet/_main.html
+++ b/atlas/templates/speciesSheet/_main.html
@@ -72,12 +72,43 @@
 
 {% block content %}
     <div class="container-fluid">
-    <div class="row">
-        <!--Left row-->
-        <div class="col-lg-7 col-md-8 col-sm-12 col-xs-12">
-            {% include 'templates/speciesSheet/identityCard.html' %}
-            {% include 'templates/speciesSheet/map.html' %}
-            {% include 'templates/speciesSheet/otherInformations.html' %}
+        <div class="row">
+            <!--Left row-->
+            <div class="col-lg-7 col-md-8 col-sm-12 col-xs-12">
+                {% include 'templates/speciesSheet/identityCard.html' %}
+                {% if liensImportants %}
+                <div class="liens-importants-container mt-4">
+                    {% for lien in liensImportants %}
+                    <a
+                            class="lien-important lien-important-type-{{ lien.id_type }}"
+                            href="{{ lien.path }}">
+                        {% if lien.icon %}
+                        <img src="{{ lien.icon }}" alt="" />
+                        {% endif %}
+                        <span>{{ lien.title }}</span>
+                    </a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+                {% include 'templates/speciesSheet/map.html' %}
+                {% include 'templates/speciesSheet/otherInformations.html' %}
+            </div>
+
+            <!--Right row-->
+            <div class="col-lg-5 col-md-5 col-sm-12 col-xs-12">
+                {% if photoCarousel | length >= 1 %}
+                    {% include 'templates/speciesSheet/photoCarousel.html' %}
+                {% endif %}
+
+
+                {% include 'templates/speciesSheet/blocInfos.html' %}
+
+                {% if (videoAudio.video | length > 0 ) or (videoAudio.audio | length > 0) %}
+                    {% include 'templates/speciesSheet/audioVideo.html' %}
+                {% endif %}
+
+                {% include 'templates/speciesSheet/charts.html' %}
+            </div>
         </div>
 
         <!--Right row-->

--- a/atlas/templates/speciesSheet/_main.html
+++ b/atlas/templates/speciesSheet/_main.html
@@ -81,7 +81,8 @@
                     {% for lien in liensImportants %}
                     <a
                             class="lien-important lien-important-type-{{ lien.id_type }}"
-                            href="{{ lien.path }}">
+                            href="{{ lien.path }}"
+                            target="_blank">
                         {% if lien.icon %}
                         <img src="{{ lien.icon }}" alt="" />
                         {% endif %}

--- a/atlas/templates/speciesSheet/_main.html
+++ b/atlas/templates/speciesSheet/_main.html
@@ -77,18 +77,20 @@
             <div class="col-lg-7 col-md-8 col-sm-12 col-xs-12">
                 {% include 'templates/speciesSheet/identityCard.html' %}
                 {% if liensImportants %}
-                <div class="liens-importants-container mt-4">
-                    {% for lien in liensImportants %}
-                    <a
-                            class="lien-important lien-important-type-{{ lien.id_type }}"
-                            href="{{ lien.path }}"
-                            target="_blank">
-                        {% if lien.icon %}
-                        <img src="{{ lien.icon }}" alt="" />
-                        {% endif %}
-                        <span>{{ lien.title }}</span>
-                    </a>
-                    {% endfor %}
+                <div class="card mt-4">
+                    <div class="card-body liens-importants-container">
+                        {% for lien in liensImportants %}
+                        <a
+                                class="lien-important lien-important-type-{{ lien.id_type }}"
+                                href="{{ lien.path }}"
+                                target="_blank">
+                            {% if lien.icon %}
+                            <img src="{{ lien.icon }}" alt="" />
+                            {% endif %}
+                            <span>{{ lien.title }}</span>
+                        </a>
+                        {% endfor %}
+                    </div>
                 </div>
                 {% endif %}
                 {% include 'templates/speciesSheet/map.html' %}
@@ -112,21 +114,6 @@
             </div>
         </div>
 
-        <!--Right row-->
-        <div class="col-lg-5 col-md-5 col-sm-12 col-xs-12">
-            {% if photoCarousel | length >= 1 %}
-                {% include 'templates/speciesSheet/photoCarousel.html' %}
-            {% endif %}
-
-
-            {% include 'templates/speciesSheet/blocInfos.html' %}
-
-            {% if (videoAudio.video | length > 0 ) or (videoAudio.audio | length > 0) %}
-                {% include 'templates/speciesSheet/audioVideo.html' %}
-            {% endif %}
-
-            {% include 'templates/speciesSheet/charts.html' %}
-        </div>
     </div>
     <div>
 {% endblock %}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ CHANGELOG
 - Changement de la notion de "commune" en notion de "territoire" (#545 @juggler31)
 - Ajout d'un graphique de provenance des données (#538)
 Les changements effectués afin de pouvoir changer la notion de `commune` en `territoire` necessitent un changement dans les fichiers:
+- Ajout de "liens importants" sur les fiches taxons. Cette fonctionnalité permet par exemple de mettre en avant des démarches ou des ressources additionelles sur un taxon: un lien vers une plateforme de contribution collaborative, un lien vers une fiche détaillé sur l'espèce etc... Voir le paramètre `TYPES_MEDIAS_LIENS_IMPORTANTS`
 
 `navbar.html`
 Le `form` devient :


### PR DESCRIPTION
Ref #535 

Ajout d'une fonctionnalité pour mettre en évidence certains médias TH sur la fiche espèce = types « Liens importants ».

PR en draft pour le moment, ne pas merger cette PR avant les fonctionnalités plus importantes en cours d'ajout (floutage des mailles, etc).

Exemple de rendu :

![Capture d’écran du 2025-02-03 14-18-51](https://github.com/user-attachments/assets/761f42d1-a26c-4581-8d4f-2312ab91f9e2)

Exemple avec personnalisation (vue mobile) :

![Capture d’écran du 2025-02-03 16-52-24](https://github.com/user-attachments/assets/6af1d2c7-f163-4201-9168-6242d50f518b)



