### PR TITLE
fix application root 

### DIFF
--- a/atlas/app.py
+++ b/atlas/app.py
@@ -56,9 +56,6 @@ def create_app():
         from atlas.atlasAPI import api
 
         app.register_blueprint(api, url_prefix="/api")
-
-        if "SCRIPT_NAME" not in os.environ and "APPLICATION_ROOT" in app.config:
-            os.environ["SCRIPT_NAME"] = app.config["APPLICATION_ROOT"].rstrip("/")
         app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1)
 
         app.wsgi_app = SharedDataMiddleware(

--- a/atlas/configuration/config_parser.py
+++ b/atlas/configuration/config_parser.py
@@ -1,5 +1,5 @@
 """
-Utils pour lire le fichier de conf et le valider selon le schéma Marshmallow 
+Utils pour lire le fichier de conf et le valider selon le schéma Marshmallow
 """
 
 from importlib.machinery import SourceFileLoader

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -5,6 +5,7 @@ from marshmallow import (
     ValidationError,
     validates_schema,
     EXCLUDE,
+    post_load,
 )
 from marshmallow.validate import Regexp
 
@@ -237,3 +238,11 @@ class AtlasConfig(Schema):
             raise ValidationError(
                 {"Le champ TAXHUB_URL doit être rempli si REDIMENSIONNEMENT_IMAGE = True"}
             )
+
+    @post_load
+    def post_load(self, data, **kwargs):
+        # Set APPLICATION_ROOT Flask parameter (use for url_for etc...) https://flask.palletsprojects.com/en/stable/config/#APPLICATION_ROOT
+        # the parameter is infered from URL_APPLICATION which is widely use in all the application
+        url_application = data["URL_APPLICATION"]
+        data["APPLICATION_ROOT"] = url_application if url_application != "/" else "/"
+        return data


### PR DESCRIPTION
Quand l'application est servi derrière un suffixe (/atlas), il faut que le paramètre `APPLICATION_ROOT` de flask soit renseigné correctement (il est utilisé pour construire les lien via `url_for` ). Comme un paramètre `URL_APPLICATION` existe déjà et qu'il est largement utilisé dans l'application, on déduit `APPLICATION_ROOT` de `URL_APPLICATION`
fix https://github.com/PnX-SI/GeoNature-atlas/issues/612