### PR TITLE
Correction du chemin vers les audio et video hébergées

### DIFF
--- a/atlas/modeles/repositories/vmMedias.py
+++ b/atlas/modeles/repositories/vmMedias.py
@@ -97,7 +97,7 @@ def switchMedia(row):
     if not row.chemin and not row.url:
         return None
     elif row.chemin:
-        goodPath = row.chemin
+        goodPath = utils.findPath(row)
     else:
         goodPath = row.url
 


### PR DESCRIPTION
Les fichiers de type audio et vidéo hébergés depuis taxhub (localisation indiquée dans le champ `chemin` de VM `atlas.vm_medias`) ne sont pas accessibles car leur chemin est mal construit.
La correction fonctionne sur les audios. A vérifier sur les vidéos.